### PR TITLE
Proxy server

### DIFF
--- a/src/main/scripts/webpack.config.js
+++ b/src/main/scripts/webpack.config.js
@@ -101,9 +101,9 @@ module.exports = {
     historyApiFallback: true,
     port: 7000,
     proxy: {
-      '/engine': {
-        target: 'http://127.0.0.1:8080/engine',
-        pathRewrite: {'^/engine' : ''}
+      '/lumeer-engine': {
+        target: 'http://127.0.0.1:8080/lumeer-engine',
+        pathRewrite: {'^/lumeer-engine' : ''}
       }
     }
   }

--- a/src/main/scripts/webpack.config.js
+++ b/src/main/scripts/webpack.config.js
@@ -99,6 +99,12 @@ module.exports = {
   devServer: {
     contentBase: path.join(__dirname, "dist"),
     historyApiFallback: true,
-    port: 7000
+    port: 7000,
+    proxy: {
+      '/engine': {
+        target: 'http://127.0.0.1:8080/engine',
+        pathRewrite: {'^/engine' : ''}
+      }
+    }
   }
 };


### PR DESCRIPTION
Webpack proxy has been enabled, this helps us to combine UI with engine much easily.

### Local run
1) If you want to test it locally run lumeer engine on wildfly
2) Run lumeer UI `npm start` in `src/main/srcipts`

Requests can be now made by calling `/lumeer-engine/*` webpack proxy will redirect the request to `http://localhost:8080/lumeer-engine/*`

### Production run
Both `lumeer-engine` and `ui` has to be on same server, requests will be handled by server itself.

### Additional notes
There might be problems with keycloak in UI, this can be avoided by adding `"disabled": true` in `src/main/scripts/webapp/WEB-INF/keycloak.json`