### PR TITLE
Update Angular Perfect Scrollbar dependency

### DIFF
--- a/src/main/scripts/package.json
+++ b/src/main/scripts/package.json
@@ -63,7 +63,7 @@
     "@angular/platform-browser-dynamic": "~4.0.0",
     "@angular/router": "~4.0.0",
     "angular2-drag-scroll": "^1.2.6",
-    "angular2-perfect-scrollbar": "^2.0.2",
+    "ngx-perfect-scrollbar": "^4.0.0",
     "jquery-slimscroll": "^1.3.8",
     "lodash": "^4.17.4",
     "ng2-slimscroll": "^1.2.1",

--- a/src/main/scripts/src/app.module.ts
+++ b/src/main/scripts/src/app.module.ts
@@ -17,7 +17,7 @@ import { DragScrollModule } from 'angular2-drag-scroll';
 import {DocumentNavigationService} from './services/document-navigation.service';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {CompanyChooser} from './viewport/company_chooser/company-chooser.component';
-import {PerfectScrollbarModule} from 'angular2-perfect-scrollbar';
+import {PerfectScrollbarModule} from 'ngx-perfect-scrollbar';
 
 const appRoutes: Routes = [
   {path: '', redirectTo: '/views/research', pathMatch: 'full'}

--- a/src/main/scripts/src/components/common/common-components.module.ts
+++ b/src/main/scripts/src/components/common/common-components.module.ts
@@ -12,7 +12,7 @@ import {UserTagComponent} from './user-tile/user-tag.component';
 import {DocumentLinksRowsComponent} from './document/links/documents-links-rows.component';
 import {LinksComponent} from './document/links/links.component';
 import {DocumentsRowsComponent} from './document/documents-rows.component';
-import {PerfectScrollbarModule} from 'angular2-perfect-scrollbar';
+import {PerfectScrollbarModule} from 'ngx-perfect-scrollbar';
 
 @NgModule({
   imports: [

--- a/src/main/scripts/src/components/views/views.module.ts
+++ b/src/main/scripts/src/components/views/views.module.ts
@@ -26,7 +26,7 @@ import {
   DocumentContentComponent
 } from './research';
 import {BrowserModule} from '@angular/platform-browser';
-import {PerfectScrollbarModule} from 'angular2-perfect-scrollbar';
+import {PerfectScrollbarModule} from 'ngx-perfect-scrollbar';
 import {DocumentInfoService} from '../../services/document-info.service';
 import {CollectionService} from '../../services/collection.service';
 import {EmptyResultComponent} from './research/empty-result.component';

--- a/src/main/scripts/src/vendor.ts
+++ b/src/main/scripts/src/vendor.ts
@@ -21,6 +21,6 @@ import './js/custom.js';
 import 'socket.io-client';
 import 'angular2-drag-scroll';
 // import 'lodash';
-import 'angular2-perfect-scrollbar';
+import 'ngx-perfect-scrollbar';
 import 'ng2-webstorage';
 window['Keycloak'] = require('./js/keycloak.js');


### PR DESCRIPTION
There is a warning when installing the project with `angular2-perfect-scrollbar` so I have updated it to the latest version `ngx-perfect-scrollbar` which supports Angular 4.

The same problem is with `angular2-drag-scroll`, however, I have not been able to find a new version of this library for Angular 4.