### PR TITLE
Enable ECMAScript 2017 constructs

### DIFF
--- a/src/main/scripts/tsconfig.json
+++ b/src/main/scripts/tsconfig.json
@@ -8,7 +8,8 @@
     "experimentalDecorators": true,
     "removeComments": false,
     "skipLibCheck": true,
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "lib": ["es2017", "dom"]
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
@kubedo8, we will be able to use new functionality such as [Array.includes()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes) now.