### PR TITLE
Update to TypeScript 2.4

### DIFF
--- a/src/main/scripts/package.json
+++ b/src/main/scripts/package.json
@@ -52,7 +52,7 @@
     "ts-loader": "2.0.3",
     "tslint": "^4.3.1",
     "tslint-loader": "^3.3.0",
-    "typescript": "~2.3.0",
+    "typescript": "~2.4.0",
     "typings": "2.1.0",
     "url-loader": "^0.5.7",
     "webpack": "^2.2.0",
@@ -78,7 +78,7 @@
     "ngx-perfect-scrollbar": "^4.0.0",
     "perfect-scrollbar": "^0.6.16",
     "respond": "^0.9.0",
-    "rxjs": "5.2.0",
+    "rxjs": "5.4.3",
     "socket.io-client": "^1.7.2",
     "zone.js": "^0.8.5"
   }

--- a/src/main/scripts/src/app/core/rest/collection.service.ts
+++ b/src/main/scripts/src/app/core/rest/collection.service.ts
@@ -45,7 +45,7 @@ export class CollectionService {
         .set('size', pageSize.toString());
     }
 
-    return this.http.get<Collection[]>(this.apiPrefix(), queryParams)
+    return this.http.get<Collection[]>(this.apiPrefix(), {params: queryParams})
       .catch(CollectionService.handleGlobalError);
   }
 

--- a/src/main/scripts/src/template-index.ejs
+++ b/src/main/scripts/src/template-index.ejs
@@ -17,7 +17,7 @@
 </head>
 <body>
 <app></app>
-<script src="https://unpkg.com/@reactivex/rxjs@5.2.0/dist/global/Rx.min.js"></script>
+<script src="https://unpkg.com/@reactivex/rxjs@5.4.3/dist/global/Rx.min.js"></script>
 <!-- Bootstrap related Javascripts -->
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>


### PR DESCRIPTION
I also had to:
* Fix return types of service methods.
* Update to newer RxJS with fixed type problems.

We will be able to take full advantage of [new TypeScript features](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-4.html) such as String Enums, etc.