### PR TITLE
Fix services not returning HTTP response

### DIFF
--- a/src/main/scripts/src/app/core/rest/organization.service.ts
+++ b/src/main/scripts/src/app/core/rest/organization.service.ts
@@ -19,10 +19,10 @@
  */
 
 import {Injectable} from '@angular/core';
-import {Response} from '@angular/http';
+import {HttpClient, HttpResponse} from '@angular/common/http';
+
 import {Organization} from '../dto/organization';
 import {Observable} from 'rxjs/Observable';
-import {HttpClient} from '@angular/common/http';
 import 'rxjs/add/operator/map';
 
 @Injectable()
@@ -39,16 +39,16 @@ export class OrganizationService {
     return this.httpClient.get<Organization>(OrganizationService.apiPrefix(code));
   }
 
-  public deleteOrganization(code: string): Observable<Response> {
-    return this.httpClient.delete(OrganizationService.apiPrefix(code));
+  public deleteOrganization(code: string): Observable<HttpResponse<object>> {
+    return this.httpClient.delete(OrganizationService.apiPrefix(code), {observe: 'response'});
   }
 
-  public createOrganization(organization: Organization): Observable<Response> {
-    return this.httpClient.post(OrganizationService.apiPrefix(), organization);
+  public createOrganization(organization: Organization): Observable<HttpResponse<object>> {
+    return this.httpClient.post(OrganizationService.apiPrefix(), organization, {observe: 'response'});
   }
 
-  public editOrganization(code: string, organization: Organization): Observable<Response> {
-    return this.httpClient.put(OrganizationService.apiPrefix(code), organization);
+  public editOrganization(code: string, organization: Organization): Observable<HttpResponse<object>> {
+    return this.httpClient.put(OrganizationService.apiPrefix(code), organization, {observe: 'response'});
   }
 
   private static apiPrefix(code?: string): string {

--- a/src/main/scripts/src/app/core/rest/project.service.ts
+++ b/src/main/scripts/src/app/core/rest/project.service.ts
@@ -19,10 +19,11 @@
  */
 
 import {Injectable} from '@angular/core';
-import {Response} from '@angular/http';
+import {HttpResponse} from '@angular/common/http';
+import {HttpClient} from '@angular/common/http';
+
 import {Project} from '../dto/project';
 import {Observable} from 'rxjs/Observable';
-import {HttpClient} from '@angular/common/http';
 import 'rxjs/add/operator/map';
 
 @Injectable()
@@ -39,16 +40,16 @@ export class ProjectService {
     return this.httpClient.get<Project>(ProjectService.apiPrefix(orgCode, projCode));
   }
 
-  public deleteProject(orgCode: string, projCode: string): Observable<Response> {
-    return this.httpClient.delete(ProjectService.apiPrefix(orgCode, projCode));
+  public deleteProject(orgCode: string, projCode: string): Observable<HttpResponse<object>> {
+    return this.httpClient.delete(ProjectService.apiPrefix(orgCode, projCode), {observe: 'response'});
   }
 
-  public createProject(orgCode: string, project: Project): Observable<Response> {
-    return this.httpClient.post(ProjectService.apiPrefix(orgCode), project);
+  public createProject(orgCode: string, project: Project): Observable<HttpResponse<object>> {
+    return this.httpClient.post(ProjectService.apiPrefix(orgCode), project, {observe: 'response'});
   }
 
-  public editProject(orgCode: string, projCode: string, project: Project): Observable<Response> {
-    return this.httpClient.put(ProjectService.apiPrefix(orgCode, projCode), project);
+  public editProject(orgCode: string, projCode: string, project: Project): Observable<HttpResponse<object>> {
+    return this.httpClient.put(ProjectService.apiPrefix(orgCode, projCode), project, {observe: 'response'});
   }
 
   private static apiPrefix(orgCode: string, projCode?: string): string {

--- a/src/main/scripts/src/app/core/rest/user-settings.service.ts
+++ b/src/main/scripts/src/app/core/rest/user-settings.service.ts
@@ -19,8 +19,8 @@
  */
 
 import {Injectable} from '@angular/core';
-import {Response} from '@angular/http';
-import {HttpClient} from '@angular/common/http';
+import {HttpClient, HttpResponse} from '@angular/common/http';
+
 import {UserSettings} from '../dto/user.settings';
 import {Observable} from 'rxjs/Observable';
 
@@ -34,8 +34,8 @@ export class UserSettingsService {
     return this.httpClient.get<UserSettings>(UserSettingsService.apiPrefix());
   }
 
-  public updateUserSettings(userSettings: UserSettings): Observable<Response> {
-    return this.httpClient.put(UserSettingsService.apiPrefix(), userSettings);
+  public updateUserSettings(userSettings: UserSettings): Observable<HttpResponse<object>> {
+    return this.httpClient.put(UserSettingsService.apiPrefix(), userSettings, {observe: 'response'});
   }
 
   private static apiPrefix(): string {


### PR DESCRIPTION
Services were returning `null` instead of an `Response`

So it's possible to check response status code until the backend services are refactored to return responses even for `put`, `post` and `delete`.