### PR TITLE
Add http and keycloak providers

### DIFF
--- a/src/main/scripts/src/app/core/core.module.ts
+++ b/src/main/scripts/src/app/core/core.module.ts
@@ -39,6 +39,7 @@ import {SearchService} from './rest/search.service';
 import {RouterModule} from '@angular/router';
 import {LumeerErrorHandler} from './error/lumeer-error.handler';
 import {ImportService} from './rest/import.service';
+import {KEYCLOAK_HTTP_PROVIDER, KeycloakHttp} from './keycloak/keycloak-http.service';
 
 @NgModule({
   imports: [
@@ -64,6 +65,8 @@ import {ImportService} from './rest/import.service';
     UserSettingsService,
     WorkspaceService,
     ImportService,
+    KEYCLOAK_HTTP_PROVIDER,
+    KeycloakHttp,
     {provide: ErrorHandler, useClass: LumeerErrorHandler}
   ],
   exports: [

--- a/src/main/scripts/src/app/core/keycloak/keycloak-http.service.ts
+++ b/src/main/scripts/src/app/core/keycloak/keycloak-http.service.ts
@@ -1,0 +1,44 @@
+import {Injectable} from '@angular/core';
+import {ConnectionBackend, Headers, Http, Request, RequestOptions, RequestOptionsArgs, Response, XHRBackend} from '@angular/http';
+
+import {KeycloakService} from './keycloak.service';
+import {Observable} from 'rxjs';
+
+/**
+ * This provides a wrapper over the ng2 Http class that insures tokens are refreshed on each request.
+ */
+@Injectable()
+export class KeycloakHttp extends Http {
+  constructor(_backend: ConnectionBackend, _defaultOptions: RequestOptions, private _keycloakService: KeycloakService) {
+    super(_backend, _defaultOptions);
+  }
+
+  public request(url: string | Request, options?: RequestOptionsArgs): Observable<Response> {
+    const tokenPromise: Promise<string> = this._keycloakService.getToken();
+    const tokenObservable: Observable<string> = Observable.fromPromise(tokenPromise);
+
+    if (typeof url === 'string') {
+      return tokenObservable.map(token => {
+        const authOptions = new RequestOptions({headers: new Headers({'Authorization': 'Bearer ' + token})});
+        return new RequestOptions().merge(options).merge(authOptions);
+      }).concatMap(opts => super.request(url, opts));
+    } else if (url instanceof Request) {
+      return tokenObservable.map(token => {
+        url.headers.set('Authorization', 'Bearer ' + token);
+        return url;
+      }).concatMap(request => super.request(request));
+    }
+  }
+}
+
+export function keycloakHttpFactory(backend: XHRBackend,
+                                    defaultOptions: RequestOptions,
+                                    keycloakService: KeycloakService) {
+  return new KeycloakHttp(backend, defaultOptions, keycloakService);
+}
+
+export const KEYCLOAK_HTTP_PROVIDER = {
+  provide: Http,
+  useFactory: keycloakHttpFactory,
+  deps: [XHRBackend, RequestOptions, KeycloakService]
+};

--- a/src/main/scripts/src/app/core/keycloak/keycloak.service.ts
+++ b/src/main/scripts/src/app/core/keycloak/keycloak.service.ts
@@ -1,0 +1,66 @@
+import {Injectable} from '@angular/core';
+
+declare let Keycloak: any;
+
+@Injectable()
+export class KeycloakService {
+  public static auth: any = {};
+
+  public static init(): Promise<any> {
+    let kcSetting = require('../../../../../webapp/WEB-INF/keycloak.json');
+    const keycloakAuth: any = Keycloak({
+      url: kcSetting['auth-server-url'],
+      realm: kcSetting.realm,
+      clientId: kcSetting.resource,
+    });
+
+    KeycloakService.auth.loggedIn = false;
+    KeycloakService.auth.isDisabled = kcSetting.disabled || LUMEER_ENV === 'development';
+    kcSetting.disabled = kcSetting.disabled || LUMEER_ENV === 'development';
+    return new Promise((resolve, reject) => {
+      if (kcSetting.disabled) {
+        resolve();
+      } else {
+        keycloakAuth.init({ onLoad: 'login-required', checkLoginIframe: false})
+          .success(() => {
+            KeycloakService.auth.loggedIn = true;
+            KeycloakService.auth.authz = keycloakAuth;
+            KeycloakService.auth.logoutUrl = keycloakAuth.authServerUrl
+              + `/realms/${kcSetting.realm}/protocol/openid-connect/logout?redirect_uri=`
+              + document.baseURI;
+            resolve();
+          })
+          .error(() => {
+            reject();
+          });
+      }
+    });
+  }
+
+  public  logout() {
+    console.log('*** LOGOUT');
+    KeycloakService.auth.loggedIn = false;
+    KeycloakService.auth.authz = null;
+
+    window.location.href = KeycloakService.auth.logoutUrl;
+  }
+
+  public getToken(): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      if (KeycloakService.auth.authz && KeycloakService.auth.authz.token) {
+        KeycloakService.auth.authz
+          .updateToken(5)
+          .success(() => {
+            resolve(<string>KeycloakService.auth.authz.token);
+          })
+          .error(() => {
+            reject('Failed to refresh token');
+          });
+      } else if (KeycloakService.auth.isDisabled) {
+        resolve();
+      } else {
+        reject('Not loggen in');
+      }
+    });
+  }
+}


### PR DESCRIPTION
When we were migrating from old app file structure we forgot to include `keycloak-http.service.ts` and `keycloak.service.ts` and put them in providers field. It caused that HTTP request had no JWT and keycloak refused it's request.