### PR TITLE
Use Http interceptor based on HttpClient

### DIFF
--- a/src/main/scripts/src/app/core/core.module.ts
+++ b/src/main/scripts/src/app/core/core.module.ts
@@ -20,9 +20,9 @@
 
 import {ErrorHandler, NgModule, Optional, SkipSelf} from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {HttpClientModule} from '@angular/common/http';
+import {HTTP_INTERCEPTORS, HttpClientModule} from '@angular/common/http';
 import {FormsModule} from '@angular/forms';
-import {HttpModule} from '@angular/http';
+import {Http, HttpModule, RequestOptions, XHRBackend} from '@angular/http';
 
 import {WorkspaceService} from './workspace.service';
 import {HeaderComponent} from './header/header.component';
@@ -39,7 +39,8 @@ import {SearchService} from './rest/search.service';
 import {RouterModule} from '@angular/router';
 import {LumeerErrorHandler} from './error/lumeer-error.handler';
 import {ImportService} from './rest/import.service';
-import {KEYCLOAK_HTTP_PROVIDER, KeycloakHttp} from './keycloak/keycloak-http.service';
+import {KEYCLOAK_HTTP_PROVIDER, KeycloakInterceptor} from './keycloak/keycloak-http.service';
+import {KeycloakService} from './keycloak/keycloak.service';
 
 @NgModule({
   imports: [
@@ -65,8 +66,8 @@ import {KEYCLOAK_HTTP_PROVIDER, KeycloakHttp} from './keycloak/keycloak-http.ser
     UserSettingsService,
     WorkspaceService,
     ImportService,
+    KeycloakService,
     KEYCLOAK_HTTP_PROVIDER,
-    KeycloakHttp,
     {provide: ErrorHandler, useClass: LumeerErrorHandler}
   ],
   exports: [

--- a/src/main/scripts/src/app/core/keycloak/keycloak-http.service.ts
+++ b/src/main/scripts/src/app/core/keycloak/keycloak-http.service.ts
@@ -1,44 +1,27 @@
 import {Injectable} from '@angular/core';
-import {ConnectionBackend, Headers, Http, Request, RequestOptions, RequestOptionsArgs, Response, XHRBackend} from '@angular/http';
 
 import {KeycloakService} from './keycloak.service';
 import {Observable} from 'rxjs';
+import {HTTP_INTERCEPTORS, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from '@angular/common/http';
 
-/**
- * This provides a wrapper over the ng2 Http class that insures tokens are refreshed on each request.
- */
 @Injectable()
-export class KeycloakHttp extends Http {
-  constructor(_backend: ConnectionBackend, _defaultOptions: RequestOptions, private _keycloakService: KeycloakService) {
-    super(_backend, _defaultOptions);
+export class KeycloakInterceptor implements HttpInterceptor {
+  constructor(private _keycloakService: KeycloakService) {
   }
-
-  public request(url: string | Request, options?: RequestOptionsArgs): Observable<Response> {
+  public intercept (req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     const tokenPromise: Promise<string> = this._keycloakService.getToken();
     const tokenObservable: Observable<string> = Observable.fromPromise(tokenPromise);
 
-    if (typeof url === 'string') {
-      return tokenObservable.map(token => {
-        const authOptions = new RequestOptions({headers: new Headers({'Authorization': 'Bearer ' + token})});
-        return new RequestOptions().merge(options).merge(authOptions);
-      }).concatMap(opts => super.request(url, opts));
-    } else if (url instanceof Request) {
-      return tokenObservable.map(token => {
-        url.headers.set('Authorization', 'Bearer ' + token);
-        return url;
-      }).concatMap(request => super.request(request));
-    }
+    return tokenObservable.map(token => {
+      return req.clone({
+        headers: req.headers.set('Authorization', `Bearer ${token}`)
+      });
+    }).concatMap(request => next.handle(request));
   }
 }
 
-export function keycloakHttpFactory(backend: XHRBackend,
-                                    defaultOptions: RequestOptions,
-                                    keycloakService: KeycloakService) {
-  return new KeycloakHttp(backend, defaultOptions, keycloakService);
-}
-
 export const KEYCLOAK_HTTP_PROVIDER = {
-  provide: Http,
-  useFactory: keycloakHttpFactory,
-  deps: [XHRBackend, RequestOptions, KeycloakService]
+  provide: HTTP_INTERCEPTORS,
+  useClass: KeycloakInterceptor,
+  multi: true
 };

--- a/src/main/scripts/src/app/core/keycloak/keycloak.service.ts
+++ b/src/main/scripts/src/app/core/keycloak/keycloak.service.ts
@@ -57,7 +57,7 @@ export class KeycloakService {
             reject('Failed to refresh token');
           });
       } else if (KeycloakService.auth.isDisabled) {
-        resolve();
+        resolve('KC is disabled!');
       } else {
         reject('Not loggen in');
       }

--- a/src/main/scripts/src/boot.ts
+++ b/src/main/scripts/src/boot.ts
@@ -20,7 +20,7 @@
 
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {AppModule} from './app/app.module';
-import {KeycloakService} from './services/keycloak.service';
+import {KeycloakService} from './app/core/keycloak/keycloak.service';
 
 KeycloakService.init()
   .then(() => platformBrowserDynamic().bootstrapModule(AppModule));


### PR DESCRIPTION
When we moved to newer version of angular Http interceptors were replaced by HttpClient, so we have to use newer way of intercepting our Authentication.

Please bear in mind that KC header is:
```
Authorization:Bearer JWT_TOKEN
```