### PR TITLE
Fix error on pages without query

### DIFF
--- a/src/main/scripts/src/app/shared/utils/query-converter.ts
+++ b/src/main/scripts/src/app/shared/utils/query-converter.ts
@@ -27,7 +27,11 @@ export class QueryConverter {
   }
 
   public static fromString(query: string): Query {
-    return query ? JSON.parse(query) : {};
+    const queryObject = query ? JSON.parse(query) : {};
+    !queryObject.collectionCodes && (queryObject.collectionCodes = []);
+    !queryObject.filters && (queryObject.filters = []);
+
+    return queryObject;
   }
 
 }


### PR DESCRIPTION
Calling map and filter on `collectionCodes` and `filters` caused errors