### PR TITLE
Use AOT compilation on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
 before_install:
   - "cd src/main/scripts"
 script:
-  - npm run build
+  - "AOT=true I18N_LOCALE=sk npm run build"


### PR DESCRIPTION
It seems that people started making changes that break [AOT compilation](https://angular.io/guide/aot-compiler) so I enabled it by default on Travis builds in order to catch these problems as soon as someone submits a pull-request.