### PR TITLE
Fix direct URL access on server #LMR-494

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,28 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app version="3.1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
 
-    <module-name>lumeer-web</module-name>
-    <welcome-file-list>
-        <welcome-file>index.html</welcome-file>
-    </welcome-file-list>
+  <module-name>lumeer-web</module-name>
+  <welcome-file-list>
+    <welcome-file>index.html</welcome-file>
+  </welcome-file-list>
 
-    <security-constraint>
-        <web-resource-collection>
-            <url-pattern>/*</url-pattern>
-        </web-resource-collection>
-        <auth-constraint>
-            <role-name>scientist</role-name>
-        </auth-constraint>
-    </security-constraint>
+  <error-page>
+    <error-code>404</error-code>
+    <location>/index.html</location>
+  </error-page>
 
-    <login-config>
-        <auth-method>KEYCLOAK</auth-method>
-        <realm-name>lumeer</realm-name>
-    </login-config>
+  <security-constraint>
+    <web-resource-collection>
+      <url-pattern>/*</url-pattern>
+    </web-resource-collection>
+    <auth-constraint>
+      <role-name>scientist</role-name>
+    </auth-constraint>
+  </security-constraint>
 
-    <security-role>
-        <role-name>scientist</role-name>
-    </security-role>
+  <login-config>
+    <auth-method>KEYCLOAK</auth-method>
+    <realm-name>lumeer</realm-name>
+  </login-config>
+
+  <security-role>
+    <role-name>scientist</role-name>
+  </security-role>
 </web-app>


### PR DESCRIPTION
`index.html` is now used as an error page so the direct application URLs will work even when the application is running in WildFly AS.

The other nice thing about this is that our custom 404 page is shown (instead of blank `Not found` page provided by WildFly) when the given URL does not exist (within Angular routes).