### PR TITLE
ui/w/$ORG/$PROJ/view/postit - show frame on first arrow key press #LMR-597

### DIFF
--- a/src/app/view/perspectives/post-it/post-it-perspective.component.ts
+++ b/src/app/view/perspectives/post-it/post-it-perspective.component.ts
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {Component, ElementRef, Input, NgZone, OnDestroy, OnInit, ViewChild} from '@angular/core';
+import {Component, ElementRef, HostListener, Input, NgZone, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {filter} from 'rxjs/operators';
 import {Subscription} from 'rxjs/Subscription';
@@ -34,6 +34,7 @@ import {DeletionHelper} from './util/deletion-helper';
 import {InfiniteScroll} from './util/infinite-scroll';
 import {NavigationHelper} from './util/navigation-helper';
 import {SelectionHelper} from './util/selection-helper';
+import {KeyCode} from '../../../shared/key-code';
 import Create = DocumentsAction.Create;
 import UpdateData = DocumentsAction.UpdateData;
 
@@ -43,6 +44,21 @@ import UpdateData = DocumentsAction.UpdateData;
   styleUrls: ['./post-it-perspective.component.scss']
 })
 export class PostItPerspectiveComponent implements OnInit, OnDestroy {
+
+  @HostListener('document:keydown', ['$event'])
+  public onKeyboardClick(event: KeyboardEvent) {
+    if (!this.isNavigationKey(event.keyCode)) {
+      return;
+    }
+
+    if (this.selectionHelper) {
+      this.selectionHelper.initializeIfNeeded();
+    }
+  }
+
+  private isNavigationKey(keyCode: number): boolean {
+    return [KeyCode.UpArrow, KeyCode.DownArrow, KeyCode.LeftArrow, KeyCode.RightArrow, KeyCode.Enter].includes(keyCode);
+  }
 
   @Input()
   public editable: boolean = true;

--- a/src/app/view/perspectives/post-it/util/selection-helper.ts
+++ b/src/app/view/perspectives/post-it/util/selection-helper.ts
@@ -50,6 +50,26 @@ export class SelectionHelper {
     };
   }
 
+  public initializeIfNeeded() {
+    if (this.selectionIsEmpty()) {
+      this.select(0, 0, this.firstPostIt());
+    }
+  }
+
+  private firstPostIt(): PostItDocumentModel {
+    return this.postIts.reduce((first, current) => {
+      if (first.order <= current.order) {
+        return first;
+      } else {
+        return current;
+      }
+    });
+  }
+
+  private selectionIsEmpty(): boolean {
+    return JSON.stringify(this.selection) === JSON.stringify(this.emptySelection());
+  }
+
   public setEditMode(on: boolean): void {
     this.selection.editing = on;
   }
@@ -254,4 +274,5 @@ export class SelectionHelper {
       row === this.selection.row &&
       postItId === this.selection.documentId;
   }
+
 }


### PR DESCRIPTION
The `firstPostIt` is there just in case postIts were shuffled during user ordering.

Signed-off-by: justmesr <simon.kocurek@gmail.com>