### PR TITLE
[LMR-655] Fix

### DIFF
--- a/src/app/app.initializer.ts
+++ b/src/app/app.initializer.ts
@@ -26,6 +26,7 @@ export function appInitializer(keycloak: KeycloakService): () => Promise<any> {
       try {
         if (!KeycloakSettings.isDisabled()) {
           await keycloak.init({config: KeycloakSettings.getConfig()});
+          await keycloak.getToken();
         }
         resolve();
       } catch (error) {


### PR DESCRIPTION
App was loading twice because keycloak did authorisation process after app initialisation
Added token fetching before angular app is initialised, so app should not load twice. That also seems to fix error in setUpGoogleAnalytics method in app.component