### PR TITLE
Fix aborting REST API requests #LMR-795

### DIFF
--- a/src/app/core/rest/collection.service.ts
+++ b/src/app/core/rest/collection.service.ts
@@ -23,15 +23,15 @@ import {Injectable} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {Observable} from 'rxjs/Observable';
 import {ErrorObservable} from 'rxjs/observable/ErrorObservable';
-import {catchError, first, map, switchMap} from 'rxjs/operators';
+import {catchError, first, map, mergeMap} from 'rxjs/operators';
 import {isNullOrUndefined} from 'util';
 import {Attribute, Collection} from '../dto';
 import {BadInputError} from '../error/bad-input.error';
 import {AppState} from '../store/app.state';
+import {CollectionModel} from '../store/collections/collection.model';
+import {selectCollectionsDictionary} from '../store/collections/collections.state';
 import {HomePageService} from './home-page.service';
 import {PermissionService} from './permission.service';
-import {selectCollectionsDictionary} from "../store/collections/collections.state";
-import {CollectionModel} from "../store/collections/collection.model";
 
 // TODO add add support for Default Attribute
 @Injectable()
@@ -51,7 +51,7 @@ export class CollectionService extends PermissionService {
     this.homePageService.addLastUsedCollection(collection.id).subscribe();
     return this.httpClient.put(`${this.apiPrefix()}/${collection.id}`, collection).pipe(
       catchError(this.handleError),
-      switchMap(collection => this.homePageService.checkFavoriteCollection(collection))
+      mergeMap(collection => this.homePageService.checkFavoriteCollection(collection))
     );
   }
 
@@ -79,19 +79,19 @@ export class CollectionService extends PermissionService {
   public getCollection(collectionId: string): Observable<Collection> {
     return this.httpClient.get<Collection>(`${this.apiPrefix()}/${collectionId}`).pipe(
       catchError(CollectionService.handleGlobalError),
-      switchMap(collection => this.homePageService.checkFavoriteCollection(collection))
+      mergeMap(collection => this.homePageService.checkFavoriteCollection(collection))
     );
   }
 
   public getLastUsedCollections(): Observable<CollectionModel[]> {
     return this.homePageService.getLastUsedCollections().pipe(
-      switchMap(ids => this.convertIdsToCollections(ids))
+      mergeMap(ids => this.convertIdsToCollections(ids))
     );
   }
 
   public getFavoriteCollections(): Observable<CollectionModel[]> {
     return this.homePageService.getFavoriteCollections().pipe(
-      switchMap(ids => this.convertIdsToCollections(ids))
+      mergeMap(ids => this.convertIdsToCollections(ids))
     );
   }
 
@@ -105,7 +105,7 @@ export class CollectionService extends PermissionService {
 
     return this.httpClient.get<Collection[]>(this.apiPrefix(), {params: queryParams}).pipe(
       catchError(CollectionService.handleGlobalError),
-      switchMap(collections => this.homePageService.checkFavoriteCollections(collections))
+      mergeMap(collections => this.homePageService.checkFavoriteCollections(collections))
     );
   }
 
@@ -162,7 +162,7 @@ export class CollectionService extends PermissionService {
       first(),
       map(collectionsDictionary => {
         return ids.map(id => collectionsDictionary[id])
-          .filter(collection => collection)
+          .filter(collection => collection);
       })
     );
   }

--- a/src/app/core/rest/document.service.ts
+++ b/src/app/core/rest/document.service.ts
@@ -22,7 +22,7 @@ import {Injectable} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {Observable} from 'rxjs/Observable';
 import {ErrorObservable} from 'rxjs/observable/ErrorObservable';
-import {catchError, map, switchMap, tap} from 'rxjs/operators';
+import {catchError, map, mergeMap, tap} from 'rxjs/operators';
 import {isNullOrUndefined} from 'util';
 
 import {Document} from '../dto/document';
@@ -52,7 +52,7 @@ export class DocumentService {
       catchError(error => this.handleGlobalError(error)),
       map(response => response.headers.get('Location').split('/').pop()),
       tap(id => this.addLastUsed(document.collectionId, id)),
-      switchMap(id => {
+      mergeMap(id => {
         document.id = id;
         return Observable.of(document);
       })
@@ -67,7 +67,7 @@ export class DocumentService {
         map(returnedDocument => {
           return {...returnedDocument, collectionId: document.collectionId};
         }),
-        switchMap(document => this.homePageService.checkFavoriteDocument(document))
+        mergeMap(document => this.homePageService.checkFavoriteDocument(document))
       );
   }
 
@@ -76,7 +76,7 @@ export class DocumentService {
     return this.httpClient.patch<Document>(`${this.apiPrefix(document.collectionId)}/${document.id}/data`, document.data)
       .pipe(
         catchError(error => this.handleGlobalError(error)),
-        switchMap(document => this.homePageService.checkFavoriteDocument(document))
+        mergeMap(document => this.homePageService.checkFavoriteDocument(document))
       );
   }
 
@@ -99,19 +99,19 @@ export class DocumentService {
     return this.httpClient.get<Document>(`${this.apiPrefix(collectionId)}/${documentId}`)
       .pipe(
         catchError(error => this.handleGlobalError(error)),
-        switchMap(document => this.homePageService.checkFavoriteDocument(document))
+        mergeMap(document => this.homePageService.checkFavoriteDocument(document))
       );
   }
 
   public getLastUsedDocuments(): Observable<Document[]> {
     return this.homePageService.getLastUsedDocuments().pipe(
-      switchMap(ids => this.convertIdsToDocuments(ids))
+      mergeMap(ids => this.convertIdsToDocuments(ids))
     );
   }
 
   public getFavoriteDocuments(): Observable<Document[]> {
     return this.homePageService.getFavoriteDocuments().pipe(
-      switchMap(ids => this.convertIdsToDocuments(ids))
+      mergeMap(ids => this.convertIdsToDocuments(ids))
     );
   }
 
@@ -126,7 +126,7 @@ export class DocumentService {
     return this.httpClient.get<Document[]>(this.apiPrefix(collectionId), {params: queryParams})
       .pipe(
         catchError(error => this.handleGlobalError(error)),
-        switchMap(documents => this.homePageService.checkFavoriteDocuments(documents))
+        mergeMap(documents => this.homePageService.checkFavoriteDocuments(documents))
       );
   }
 

--- a/src/app/core/rest/home-page.service.ts
+++ b/src/app/core/rest/home-page.service.ts
@@ -20,7 +20,7 @@
 import {Injectable} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {Observable} from 'rxjs/Observable';
-import {switchMap} from 'rxjs/operators';
+import {mergeMap} from 'rxjs/operators';
 import {LocalStorage} from '../../shared/utils/local-storage';
 import {Collection, Document} from '../dto';
 import {AppState} from '../store/app.state';
@@ -113,7 +113,7 @@ export class HomePageService {
 
   public checkFavoriteDocument(document: Document): Observable<Document> {
     return this.getFavoriteDocuments().pipe(
-      switchMap(codes => {
+      mergeMap(codes => {
         document.favorite = codes.includes(this.documentValue(document.collectionId, document.id));
         return Observable.of(document);
       })
@@ -122,7 +122,7 @@ export class HomePageService {
 
   public checkFavoriteDocuments(documents: Document[]): Observable<Document[]> {
     return this.getFavoriteDocuments().pipe(
-      switchMap(codes => {
+      mergeMap(codes => {
         for (let document of documents) {
           document.favorite = codes.includes(this.documentValue(document.collectionId, document.id));
         }
@@ -133,7 +133,7 @@ export class HomePageService {
 
   public checkFavoriteCollection(collection: Collection): Observable<Collection> {
     return this.getFavoriteCollections().pipe(
-      switchMap(codes => {
+      mergeMap(codes => {
         collection.favorite = codes.includes(collection.id);
         return Observable.of(collection);
       })
@@ -142,7 +142,7 @@ export class HomePageService {
 
   public checkFavoriteCollections(collections: Collection[]): Observable<Collection[]> {
     return this.getFavoriteCollections().pipe(
-      switchMap(codes => {
+      mergeMap(codes => {
         for (let collection of collections) {
           collection.favorite = codes.includes(collection.id);
         }

--- a/src/app/core/rest/organization.service.ts
+++ b/src/app/core/rest/organization.service.ts
@@ -17,14 +17,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {HttpErrorResponse, HttpResponse} from '@angular/common/http';
+import {HttpResponse} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
-import {ErrorObservable} from 'rxjs/observable/ErrorObservable';
-import {catchError, map, switchMap} from 'rxjs/operators';
 import {Organization} from '../dto';
-import {FetchFailedError} from '../error/fetch-failed.error';
-import {NetworkError} from '../error/network.error';
 import {PermissionService} from './permission.service';
 
 @Injectable()

--- a/src/app/core/rest/project.service.ts
+++ b/src/app/core/rest/project.service.ts
@@ -17,16 +17,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {HttpErrorResponse, HttpResponse} from '@angular/common/http';
+import {HttpResponse} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
-import {ErrorObservable} from 'rxjs/observable/ErrorObservable';
-import {catchError, map, switchMap} from 'rxjs/operators';
 import {Project} from '../dto';
-import {FetchFailedError} from '../error/fetch-failed.error';
-import {NetworkError} from '../error/network.error';
-import {PermissionService} from './permission.service';
 import {LumeerError} from '../error/lumeer.error';
+import {PermissionService} from './permission.service';
 
 @Injectable()
 export class ProjectService extends PermissionService {

--- a/src/app/core/rest/search.service.ts
+++ b/src/app/core/rest/search.service.ts
@@ -17,23 +17,22 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {Injectable} from '@angular/core';
 import {HttpClient, HttpErrorResponse, HttpParams} from '@angular/common/http';
+import {Injectable} from '@angular/core';
 import {Store} from '@ngrx/store';
-import {Suggestions} from '../dto/suggestions';
-import {Query} from '../dto/query';
-import {Collection} from '../dto/collection';
-import {LumeerError} from '../error/lumeer.error';
-import {ErrorObservable} from 'rxjs/observable/ErrorObservable';
-import {Document} from '../dto/document';
-import {View} from '../dto/view';
-import {SuggestionType} from '../dto/suggestion-type';
 import {Observable} from 'rxjs/Observable';
-import {catchError, filter, map, switchMap} from 'rxjs/operators';
-import {Workspace} from '../store/navigation/workspace.model';
+import {ErrorObservable} from 'rxjs/observable/ErrorObservable';
+import {catchError, filter, mergeMap} from 'rxjs/operators';
+import {Collection} from '../dto/collection';
+import {Document} from '../dto/document';
+import {Query} from '../dto/query';
+import {SuggestionType} from '../dto/suggestion-type';
+import {Suggestions} from '../dto/suggestions';
+import {View} from '../dto/view';
+import {LumeerError} from '../error/lumeer.error';
 import {AppState} from '../store/app.state';
 import {selectWorkspace} from '../store/navigation/navigation.state';
-import {isNullOrUndefined} from 'util';
+import {Workspace} from '../store/navigation/workspace.model';
 import {HomePageService} from './home-page.service';
 
 @Injectable()
@@ -60,7 +59,7 @@ export class SearchService {
     return this.http.post<Collection[]>(`${this.searchPath()}/collections`, query)
       .pipe(
         catchError(SearchService.handleError),
-        switchMap(collections => this.homePageService.checkFavoriteCollections(collections))
+        mergeMap(collections => this.homePageService.checkFavoriteCollections(collections))
       );
   }
 
@@ -68,7 +67,7 @@ export class SearchService {
     return this.http.post<Document[]>(`${this.searchPath()}/documents`, query)
       .pipe(
         catchError(SearchService.handleError),
-        switchMap(documents => this.homePageService.checkFavoriteDocuments(documents)));
+        mergeMap(documents => this.homePageService.checkFavoriteDocuments(documents)));
   }
 
   public searchViews(query: Query): Observable<View[]> {

--- a/src/app/core/store/collections/collections.effects.ts
+++ b/src/app/core/store/collections/collections.effects.ts
@@ -18,11 +18,11 @@
  */
 
 import {Injectable} from '@angular/core';
-import {Actions, Effect} from '@ngrx/effects';
+import {Actions, Effect, ofType} from '@ngrx/effects';
 import {Action} from '@ngrx/store';
 import {I18n} from '@ngx-translate/i18n-polyfill';
 import {Observable} from 'rxjs/Observable';
-import {catchError, flatMap, map, switchMap, tap} from 'rxjs/operators';
+import {catchError, flatMap, map, mergeMap, tap} from 'rxjs/operators';
 import {Collection, Permission} from '../../dto';
 import {CollectionService, ImportService, SearchService} from '../../rest';
 import {HomePageService} from '../../rest/home-page.service';
@@ -38,8 +38,9 @@ import {CollectionsAction, CollectionsActionType} from './collections.action';
 export class CollectionsEffects {
 
   @Effect()
-  public get$: Observable<Action> = this.actions$.ofType<CollectionsAction.Get>(CollectionsActionType.GET).pipe(
-    switchMap((action) => {
+  public get$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.Get>(CollectionsActionType.GET),
+    mergeMap((action) => {
       const queryDto = QueryConverter.toDto(action.payload.query);
 
       return this.searchService.searchCollections(queryDto).pipe(
@@ -51,7 +52,8 @@ export class CollectionsEffects {
   );
 
   @Effect()
-  public getFailure$: Observable<Action> = this.actions$.ofType<CollectionsAction.GetFailure>(CollectionsActionType.GET_FAILURE).pipe(
+  public getFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.GetFailure>(CollectionsActionType.GET_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'collections.get.fail', value: 'Failed to get files'});
@@ -60,20 +62,23 @@ export class CollectionsEffects {
   );
 
   @Effect()
-  public getNames$: Observable<Action> = this.actions$.ofType<CollectionsAction.GetNames>(CollectionsActionType.GET_NAMES).pipe(
-    switchMap(() => this.collectionService.getAllCollectionNames()),
+  public getNames$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.GetNames>(CollectionsActionType.GET_NAMES),
+    mergeMap(() => this.collectionService.getAllCollectionNames()),
     map((collectionNames) => new CollectionsAction.GetNamesSuccess({collectionNames})),
     catchError((error) => Observable.of(new CollectionsAction.GetNamesFailure({error: error})))
   );
 
   @Effect({dispatch: false})
-  public getNamesFailure$: Observable<Action> = this.actions$.ofType<CollectionsAction.GetNamesFailure>(CollectionsActionType.GET_NAMES_FAILURE).pipe(
+  public getNamesFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.GetNamesFailure>(CollectionsActionType.GET_NAMES_FAILURE),
     tap((action: CollectionsAction.GetNamesFailure) => console.error(action.payload.error))
   );
 
   @Effect()
-  public create$: Observable<Action> = this.actions$.ofType<CollectionsAction.Create>(CollectionsActionType.CREATE).pipe(
-    switchMap(action => {
+  public create$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.Create>(CollectionsActionType.CREATE),
+    mergeMap(action => {
       const collectionDto = CollectionConverter.toDto(action.payload.collection);
 
       return this.collectionService.createCollection(collectionDto).pipe(
@@ -93,7 +98,8 @@ export class CollectionsEffects {
   );
 
   @Effect()
-  public createFailure$: Observable<Action> = this.actions$.ofType<CollectionsAction.CreateFailure>(CollectionsActionType.CREATE_FAILURE).pipe(
+  public createFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.CreateFailure>(CollectionsActionType.CREATE_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'collection.create.fail', value: 'Failed to create file'});
@@ -102,8 +108,9 @@ export class CollectionsEffects {
   );
 
   @Effect()
-  public import$: Observable<Action> = this.actions$.ofType<CollectionsAction.Import>(CollectionsActionType.IMPORT).pipe(
-    switchMap(action => {
+  public import$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.Import>(CollectionsActionType.IMPORT),
+    mergeMap(action => {
       return this.importService.importFile(action.payload.format, action.payload.importedCollection).pipe(
         map(collection => CollectionConverter.fromDto(collection))
       );
@@ -113,7 +120,8 @@ export class CollectionsEffects {
   );
 
   @Effect()
-  public importFailure$: Observable<Action> = this.actions$.ofType<CollectionsAction.ImportFailure>(CollectionsActionType.IMPORT_FAILURE).pipe(
+  public importFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.ImportFailure>(CollectionsActionType.IMPORT_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'collection.import.fail', value: 'Failed to import file'});
@@ -122,8 +130,9 @@ export class CollectionsEffects {
   );
 
   @Effect()
-  public update$: Observable<Action> = this.actions$.ofType<CollectionsAction.Update>(CollectionsActionType.UPDATE).pipe(
-    switchMap(action => {
+  public update$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.Update>(CollectionsActionType.UPDATE),
+    mergeMap(action => {
       const collectionDto = CollectionConverter.toDto(action.payload.collection);
 
       return this.collectionService.updateCollection(collectionDto).pipe(
@@ -135,7 +144,8 @@ export class CollectionsEffects {
   );
 
   @Effect()
-  public updateFailure$: Observable<Action> = this.actions$.ofType<CollectionsAction.UpdateFailure>(CollectionsActionType.UPDATE_FAILURE).pipe(
+  public updateFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.UpdateFailure>(CollectionsActionType.UPDATE_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'collection.update.fail', value: 'Failed to update file'});
@@ -144,14 +154,16 @@ export class CollectionsEffects {
   );
 
   @Effect()
-  public delete$: Observable<Action> = this.actions$.ofType<CollectionsAction.Delete>(CollectionsActionType.DELETE).pipe(
-    switchMap(action => this.collectionService.removeCollection(action.payload.collectionId)),
+  public delete$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.Delete>(CollectionsActionType.DELETE),
+    mergeMap(action => this.collectionService.removeCollection(action.payload.collectionId)),
     map(collectionId => new CollectionsAction.DeleteSuccess({collectionId})),
     catchError((error) => Observable.of(new CollectionsAction.DeleteFailure({error: error})))
   );
 
   @Effect()
-  public deleteFailure$: Observable<Action> = this.actions$.ofType<CollectionsAction.DeleteFailure>(CollectionsActionType.DELETE_FAILURE).pipe(
+  public deleteFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.DeleteFailure>(CollectionsActionType.DELETE_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'collection.delete.fail', value: 'Failed to delete file'});
@@ -160,8 +172,9 @@ export class CollectionsEffects {
   );
 
   @Effect()
-  public addFavorite$: Observable<Action> = this.actions$.ofType<CollectionsAction.AddFavorite>(CollectionsActionType.ADD_FAVORITE).pipe(
-    switchMap(action => this.homePageService.addFavoriteCollection(action.payload.collectionId).pipe(
+  public addFavorite$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.AddFavorite>(CollectionsActionType.ADD_FAVORITE),
+    mergeMap(action => this.homePageService.addFavoriteCollection(action.payload.collectionId).pipe(
       map(() => action.payload.collectionId)
     )),
     map((collectionId) => new CollectionsAction.AddFavoriteSuccess({collectionId})),
@@ -169,7 +182,8 @@ export class CollectionsEffects {
   );
 
   @Effect()
-  public addFavoriteFailure$: Observable<Action> = this.actions$.ofType<CollectionsAction.AddFavoriteFailure>(CollectionsActionType.ADD_FAVORITE_FAILURE).pipe(
+  public addFavoriteFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.AddFavoriteFailure>(CollectionsActionType.ADD_FAVORITE_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'collection.add.favorite.fail', value: 'Failed to add favorite file'});
@@ -178,8 +192,9 @@ export class CollectionsEffects {
   );
 
   @Effect()
-  public removeFavorite$: Observable<Action> = this.actions$.ofType<CollectionsAction.RemoveFavorite>(CollectionsActionType.REMOVE_FAVORITE).pipe(
-    switchMap(action => this.homePageService.removeFavoriteCollection(action.payload.collectionId).pipe(
+  public removeFavorite$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.RemoveFavorite>(CollectionsActionType.REMOVE_FAVORITE),
+    mergeMap(action => this.homePageService.removeFavoriteCollection(action.payload.collectionId).pipe(
       map(() => action.payload.collectionId)
     )),
     map((collectionId) => new CollectionsAction.RemoveFavoriteSuccess({collectionId})),
@@ -187,7 +202,8 @@ export class CollectionsEffects {
   );
 
   @Effect()
-  public removeFavoriteFailure$: Observable<Action> = this.actions$.ofType<CollectionsAction.RemoveFavoriteFailure>(CollectionsActionType.REMOVE_FAVORITE_FAILURE).pipe(
+  public removeFavoriteFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.RemoveFavoriteFailure>(CollectionsActionType.REMOVE_FAVORITE_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'collection.remove.favorite.fail', value: 'Failed to remove favorite file'});
@@ -196,8 +212,9 @@ export class CollectionsEffects {
   );
 
   @Effect()
-  public changeAttribute$: Observable<Action> = this.actions$.ofType<CollectionsAction.ChangeAttribute>(CollectionsActionType.CHANGE_ATTRIBUTE).pipe(
-    switchMap(action => {
+  public changeAttribute$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.ChangeAttribute>(CollectionsActionType.CHANGE_ATTRIBUTE),
+    mergeMap(action => {
       const attributeDto = CollectionConverter.toAttributeDto(action.payload.attribute);
 
       return this.collectionService.updateAttribute(action.payload.collectionId, action.payload.attributeId, attributeDto).pipe(
@@ -217,18 +234,19 @@ export class CollectionsEffects {
   );
 
   @Effect()
-  public changeAttributeFailure$: Observable<Action> = this.actions$
-    .ofType<CollectionsAction.ChangeAttributeFailure>(CollectionsActionType.CHANGE_ATTRIBUTE_FAILURE).pipe(
-      tap(action => console.error(action.payload.error)),
-      map(() => {
-        const message = this.i18n({id: 'collection.change.attribute.fail', value: 'Failed to change attribute'});
-        return new NotificationsAction.Error({message});
-      })
-    );
+  public changeAttributeFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.ChangeAttributeFailure>(CollectionsActionType.CHANGE_ATTRIBUTE_FAILURE),
+    tap(action => console.error(action.payload.error)),
+    map(() => {
+      const message = this.i18n({id: 'collection.change.attribute.fail', value: 'Failed to change attribute'});
+      return new NotificationsAction.Error({message});
+    })
+  );
 
   @Effect()
-  public removeAttribute$: Observable<Action> = this.actions$.ofType<CollectionsAction.RemoveAttribute>(CollectionsActionType.REMOVE_ATTRIBUTE).pipe(
-    switchMap(action => this.collectionService.removeAttribute(action.payload.collectionId, action.payload.attributeId).pipe(
+  public removeAttribute$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.RemoveAttribute>(CollectionsActionType.REMOVE_ATTRIBUTE),
+    mergeMap(action => this.collectionService.removeAttribute(action.payload.collectionId, action.payload.attributeId).pipe(
       map(() => action)
     )),
     map(action => new CollectionsAction.RemoveAttributeSuccess(action.payload)),
@@ -236,18 +254,19 @@ export class CollectionsEffects {
   );
 
   @Effect()
-  public removeAttributeFailure$: Observable<Action> = this.actions$
-    .ofType<CollectionsAction.RemoveAttributeFailure>(CollectionsActionType.REMOVE_ATTRIBUTE_FAILURE).pipe(
-      tap(action => console.error(action.payload.error)),
-      map(() => {
-        const message = this.i18n({id: 'collection.remove.attribute.fail', value: 'Failed to remove attribute'});
-        return new NotificationsAction.Error({message});
-      })
-    );
+  public removeAttributeFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.RemoveAttributeFailure>(CollectionsActionType.REMOVE_ATTRIBUTE_FAILURE),
+    tap(action => console.error(action.payload.error)),
+    map(() => {
+      const message = this.i18n({id: 'collection.remove.attribute.fail', value: 'Failed to remove attribute'});
+      return new NotificationsAction.Error({message});
+    })
+  );
 
   @Effect()
-  public changePermission$: Observable<Action> = this.actions$.ofType<CollectionsAction.ChangePermission>(CollectionsActionType.CHANGE_PERMISSION).pipe(
-    switchMap(action => {
+  public changePermission$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.ChangePermission>(CollectionsActionType.CHANGE_PERMISSION),
+    mergeMap(action => {
       const permissionDto: Permission = PermissionsConverter.toPermissionDto(action.payload.permission);
 
       if (action.payload.type === PermissionType.Users) {
@@ -267,18 +286,19 @@ export class CollectionsEffects {
   );
 
   @Effect()
-  public changePermissionFailure$: Observable<Action> = this.actions$
-    .ofType<CollectionsAction.ChangePermissionFailure>(CollectionsActionType.CHANGE_PERMISSION_FAILURE).pipe(
-      tap(action => console.error(action.payload.error)),
-      map(() => {
-        const message = this.i18n({id: 'collection.change.permission.fail', value: 'Failed to change file permission'});
-        return new NotificationsAction.Error({message});
-      })
-    );
+  public changePermissionFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.ChangePermissionFailure>(CollectionsActionType.CHANGE_PERMISSION_FAILURE),
+    tap(action => console.error(action.payload.error)),
+    map(() => {
+      const message = this.i18n({id: 'collection.change.permission.fail', value: 'Failed to change file permission'});
+      return new NotificationsAction.Error({message});
+    })
+  );
 
   @Effect()
-  public removePermission$: Observable<Action> = this.actions$.ofType<CollectionsAction.RemovePermission>(CollectionsActionType.REMOVE_PERMISSION).pipe(
-    switchMap(action => {
+  public removePermission$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.RemovePermission>(CollectionsActionType.REMOVE_PERMISSION),
+    mergeMap(action => {
       if (action.payload.type === PermissionType.Users) {
         return this.collectionService.removeUserPermission(action.payload.name).pipe(map(() => action));
       } else {
@@ -290,14 +310,14 @@ export class CollectionsEffects {
   );
 
   @Effect()
-  public removePermissionFailure$: Observable<Action> = this.actions$
-    .ofType<CollectionsAction.RemovePermissionFailure>(CollectionsActionType.REMOVE_PERMISSION_FAILURE).pipe(
-      tap(action => console.error(action.payload.error)),
-      map(() => {
-        const message = this.i18n({id: 'collection.remove.permission.fail', value: 'Failed to remove file permission'});
-        return new NotificationsAction.Error({message});
-      })
-    );
+  public removePermissionFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<CollectionsAction.RemovePermissionFailure>(CollectionsActionType.REMOVE_PERMISSION_FAILURE),
+    tap(action => console.error(action.payload.error)),
+    map(() => {
+      const message = this.i18n({id: 'collection.remove.permission.fail', value: 'Failed to remove file permission'});
+      return new NotificationsAction.Error({message});
+    })
+  );
 
   constructor(private actions$: Actions,
               private collectionService: CollectionService,

--- a/src/app/core/store/groups/groups.effects.ts
+++ b/src/app/core/store/groups/groups.effects.ts
@@ -18,11 +18,11 @@
  */
 
 import {Injectable} from '@angular/core';
-import {Actions, Effect} from '@ngrx/effects';
+import {Actions, Effect, ofType} from '@ngrx/effects';
 import {Action} from '@ngrx/store';
 import {I18n} from '@ngx-translate/i18n-polyfill';
 import {Observable} from 'rxjs/Observable';
-import {catchError, map, switchMap, tap} from 'rxjs/operators';
+import {catchError, map, mergeMap, tap} from 'rxjs/operators';
 import {GroupService} from '../../rest';
 import {NotificationsAction} from '../notifications/notifications.action';
 import {GroupConverter} from './group.converter';
@@ -32,8 +32,9 @@ import {GroupsAction, GroupsActionType} from './groups.action';
 export class GroupsEffects {
 
   @Effect()
-  public get$: Observable<Action> = this.actions$.ofType<GroupsAction.Get>(GroupsActionType.GET).pipe(
-    switchMap(() => this.groupService.getGroups().pipe(
+  public get$: Observable<Action> = this.actions$.pipe(
+    ofType<GroupsAction.Get>(GroupsActionType.GET),
+    mergeMap(() => this.groupService.getGroups().pipe(
       map(dtos => dtos.map(dto => GroupConverter.fromDto(dto)))
     )),
     map(groups => new GroupsAction.GetSuccess({groups: groups})),
@@ -41,7 +42,8 @@ export class GroupsEffects {
   );
 
   @Effect()
-  public getFailure$: Observable<Action> = this.actions$.ofType<GroupsAction.GetFailure>(GroupsActionType.GET_FAILURE).pipe(
+  public getFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<GroupsAction.GetFailure>(GroupsActionType.GET_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'groups.get.fail', value: 'Failed to get groups'});
@@ -50,8 +52,9 @@ export class GroupsEffects {
   );
 
   @Effect()
-  public create$: Observable<Action> = this.actions$.ofType<GroupsAction.Create>(GroupsActionType.CREATE).pipe(
-    switchMap(action => {
+  public create$: Observable<Action> = this.actions$.pipe(
+    ofType<GroupsAction.Create>(GroupsActionType.CREATE),
+    mergeMap(action => {
       const groupDto = GroupConverter.toDto(action.payload.group);
 
       return this.groupService.createGroup(groupDto).pipe(
@@ -63,7 +66,8 @@ export class GroupsEffects {
   );
 
   @Effect()
-  public createFailure$: Observable<Action> = this.actions$.ofType<GroupsAction.CreateFailure>(GroupsActionType.CREATE_FAILURE).pipe(
+  public createFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<GroupsAction.CreateFailure>(GroupsActionType.CREATE_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'group.create.fail', value: 'Failed to create group'});
@@ -72,8 +76,9 @@ export class GroupsEffects {
   );
 
   @Effect()
-  public update$: Observable<Action> = this.actions$.ofType<GroupsAction.Update>(GroupsActionType.UPDATE).pipe(
-    switchMap(action => {
+  public update$: Observable<Action> = this.actions$.pipe(
+    ofType<GroupsAction.Update>(GroupsActionType.UPDATE),
+    mergeMap(action => {
       const groupDto = GroupConverter.toDto(action.payload.group);
 
       return this.groupService.updateGroup(groupDto.id, groupDto).pipe(
@@ -85,7 +90,8 @@ export class GroupsEffects {
   );
 
   @Effect()
-  public updateFailure$: Observable<Action> = this.actions$.ofType<GroupsAction.UpdateFailure>(GroupsActionType.UPDATE_FAILURE).pipe(
+  public updateFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<GroupsAction.UpdateFailure>(GroupsActionType.UPDATE_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'group.update.fail', value: 'Failed to update group'});
@@ -94,8 +100,9 @@ export class GroupsEffects {
   );
 
   @Effect()
-  public delete$: Observable<Action> = this.actions$.ofType<GroupsAction.Delete>(GroupsActionType.DELETE).pipe(
-    switchMap(action => this.groupService.deleteGroup(action.payload.groupId).pipe(
+  public delete$: Observable<Action> = this.actions$.pipe(
+    ofType<GroupsAction.Delete>(GroupsActionType.DELETE),
+    mergeMap(action => this.groupService.deleteGroup(action.payload.groupId).pipe(
       map(() => action)
     )),
     map(action => new GroupsAction.DeleteSuccess(action.payload)),
@@ -103,7 +110,8 @@ export class GroupsEffects {
   );
 
   @Effect()
-  public deleteFailure$: Observable<Action> = this.actions$.ofType<GroupsAction.DeleteFailure>(GroupsActionType.DELETE_FAILURE).pipe(
+  public deleteFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<GroupsAction.DeleteFailure>(GroupsActionType.DELETE_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'group.delete.fail', value: 'Failed to delete group'});

--- a/src/app/core/store/link-instances/link-instances.effects.ts
+++ b/src/app/core/store/link-instances/link-instances.effects.ts
@@ -18,11 +18,11 @@
  */
 
 import {Injectable} from '@angular/core';
-import {Actions, Effect} from '@ngrx/effects';
+import {Actions, Effect, ofType} from '@ngrx/effects';
 import {Action, Store} from '@ngrx/store';
 import {I18n} from '@ngx-translate/i18n-polyfill';
 import {Observable} from 'rxjs/Observable';
-import {catchError, map, skipWhile, switchMap, tap, withLatestFrom} from 'rxjs/operators';
+import {catchError, map, mergeMap, skipWhile, tap, withLatestFrom} from 'rxjs/operators';
 import {LinkInstanceService} from '../../rest';
 import {AppState} from '../app.state';
 import {QueryHelper} from '../navigation/query.helper';
@@ -35,10 +35,11 @@ import {selectLinkInstancesQueries} from './link-instances.state';
 export class LinkInstancesEffects {
 
   @Effect()
-  public get$: Observable<Action> = this.actions$.ofType<LinkInstancesAction.Get>(LinkInstancesActionType.GET).pipe(
+  public get$: Observable<Action> = this.actions$.pipe(
+    ofType<LinkInstancesAction.Get>(LinkInstancesActionType.GET),
     withLatestFrom(this.store$.select(selectLinkInstancesQueries)),
     skipWhile(([action, queries]) => queries.some(query => QueryHelper.equal(query, action.payload.query))),
-    switchMap(([action]) => this.linkInstanceService.getLinkInstances(action.payload.query).pipe(
+    mergeMap(([action]) => this.linkInstanceService.getLinkInstances(action.payload.query).pipe(
       map(dtos => ({action, linkInstances: dtos.map(dto => LinkInstanceConverter.fromDto(dto))}))
     )),
     map(({action, linkInstances}) => new LinkInstancesAction.GetSuccess({linkInstances: linkInstances, query: action.payload.query})),
@@ -46,7 +47,8 @@ export class LinkInstancesEffects {
   );
 
   @Effect()
-  public getFailure$: Observable<Action> = this.actions$.ofType<LinkInstancesAction.GetFailure>(LinkInstancesActionType.GET_FAILURE).pipe(
+  public getFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<LinkInstancesAction.GetFailure>(LinkInstancesActionType.GET_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'link.instances.get.fail', value: 'Failed to get links'});
@@ -55,8 +57,9 @@ export class LinkInstancesEffects {
   );
 
   @Effect()
-  public create$: Observable<Action> = this.actions$.ofType<LinkInstancesAction.Create>(LinkInstancesActionType.CREATE).pipe(
-    switchMap(action => {
+  public create$: Observable<Action> = this.actions$.pipe(
+    ofType<LinkInstancesAction.Create>(LinkInstancesActionType.CREATE),
+    mergeMap(action => {
       const linkInstanceDto = LinkInstanceConverter.toDto(action.payload.linkInstance);
 
       return this.linkInstanceService.createLinkInstance(linkInstanceDto).pipe(
@@ -68,7 +71,8 @@ export class LinkInstancesEffects {
   );
 
   @Effect()
-  public createFailure$: Observable<Action> = this.actions$.ofType<LinkInstancesAction.CreateFailure>(LinkInstancesActionType.CREATE_FAILURE).pipe(
+  public createFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<LinkInstancesAction.CreateFailure>(LinkInstancesActionType.CREATE_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'link.instance.create.fail', value: 'Failed to create link'});
@@ -77,8 +81,9 @@ export class LinkInstancesEffects {
   );
 
   @Effect()
-  public update$: Observable<Action> = this.actions$.ofType<LinkInstancesAction.Update>(LinkInstancesActionType.UPDATE).pipe(
-    switchMap(action => {
+  public update$: Observable<Action> = this.actions$.pipe(
+    ofType<LinkInstancesAction.Update>(LinkInstancesActionType.UPDATE),
+    mergeMap(action => {
       const linkInstanceDto = LinkInstanceConverter.toDto(action.payload.linkInstance);
 
       return this.linkInstanceService.updateLinkInstance(action.payload.linkInstance.id, linkInstanceDto).pipe(
@@ -90,7 +95,8 @@ export class LinkInstancesEffects {
   );
 
   @Effect()
-  public updateFailure$: Observable<Action> = this.actions$.ofType<LinkInstancesAction.UpdateFailure>(LinkInstancesActionType.UPDATE_FAILURE).pipe(
+  public updateFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<LinkInstancesAction.UpdateFailure>(LinkInstancesActionType.UPDATE_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'link.instance.update.fail', value: 'Failed to update link'});
@@ -99,14 +105,16 @@ export class LinkInstancesEffects {
   );
 
   @Effect()
-  public delete$: Observable<Action> = this.actions$.ofType<LinkInstancesAction.Delete>(LinkInstancesActionType.DELETE).pipe(
-    switchMap(action => this.linkInstanceService.deleteLinkInstance(action.payload.linkInstanceId)),
+  public delete$: Observable<Action> = this.actions$.pipe(
+    ofType<LinkInstancesAction.Delete>(LinkInstancesActionType.DELETE),
+    mergeMap(action => this.linkInstanceService.deleteLinkInstance(action.payload.linkInstanceId)),
     map(linkInstanceId => new LinkInstancesAction.DeleteSuccess({linkInstanceId: linkInstanceId})),
     catchError((error) => Observable.of(new LinkInstancesAction.DeleteFailure({error: error})))
   );
 
   @Effect()
-  public deleteFailure$: Observable<Action> = this.actions$.ofType<LinkInstancesAction.DeleteFailure>(LinkInstancesActionType.DELETE_FAILURE).pipe(
+  public deleteFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<LinkInstancesAction.DeleteFailure>(LinkInstancesActionType.DELETE_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'link.instance.delete.fail', value: 'Failed to delete link'});

--- a/src/app/core/store/link-types/link-types.effects.ts
+++ b/src/app/core/store/link-types/link-types.effects.ts
@@ -18,11 +18,11 @@
  */
 
 import {Injectable} from '@angular/core';
-import {Actions, Effect} from '@ngrx/effects';
+import {Actions, Effect, ofType} from '@ngrx/effects';
 import {Action, Store} from '@ngrx/store';
 import {I18n} from '@ngx-translate/i18n-polyfill';
 import {Observable} from 'rxjs/Observable';
-import {catchError, flatMap, map, mergeMap, switchMap, tap} from 'rxjs/operators';
+import {catchError, flatMap, map, mergeMap, tap} from 'rxjs/operators';
 import {LinkTypeService} from '../../rest';
 import {AppState} from '../app.state';
 import {LinkInstancesAction} from '../link-instances/link-instances.action';
@@ -37,8 +37,9 @@ import {LinkTypesAction, LinkTypesActionType} from './link-types.action';
 export class LinkTypesEffects {
 
   @Effect()
-  public get$: Observable<Action> = this.actions$.ofType<LinkTypesAction.Get>(LinkTypesActionType.GET).pipe(
-    switchMap((action) => {
+  public get$: Observable<Action> = this.actions$.pipe(
+    ofType<LinkTypesAction.Get>(LinkTypesActionType.GET),
+    mergeMap((action) => {
       const queryDto = QueryConverter.toDto(action.payload.query);
 
       return this.linkTypeService.getLinkTypes(queryDto).pipe(
@@ -56,7 +57,8 @@ export class LinkTypesEffects {
   );
 
   @Effect()
-  public getFailure$: Observable<Action> = this.actions$.ofType<LinkTypesAction.GetFailure>(LinkTypesActionType.GET_FAILURE).pipe(
+  public getFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<LinkTypesAction.GetFailure>(LinkTypesActionType.GET_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'link.types.get.fail', value: 'Failed to get link types'});
@@ -65,8 +67,9 @@ export class LinkTypesEffects {
   );
 
   @Effect()
-  public create$: Observable<Action> = this.actions$.ofType<LinkTypesAction.Create>(LinkTypesActionType.CREATE).pipe(
-    switchMap(action => {
+  public create$: Observable<Action> = this.actions$.pipe(
+    ofType<LinkTypesAction.Create>(LinkTypesActionType.CREATE),
+    mergeMap(action => {
       const linkTypeDto = LinkTypeConverter.toDto(action.payload.linkType);
 
       return this.linkTypeService.createLinkType(linkTypeDto).pipe(
@@ -92,7 +95,8 @@ export class LinkTypesEffects {
   );
 
   @Effect()
-  public createFailure$: Observable<Action> = this.actions$.ofType<LinkTypesAction.CreateFailure>(LinkTypesActionType.CREATE_FAILURE).pipe(
+  public createFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<LinkTypesAction.CreateFailure>(LinkTypesActionType.CREATE_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'link.type.create.fail', value: 'Failed to create link type'});
@@ -101,8 +105,9 @@ export class LinkTypesEffects {
   );
 
   @Effect()
-  public update$: Observable<Action> = this.actions$.ofType<LinkTypesAction.Update>(LinkTypesActionType.UPDATE).pipe(
-    switchMap(action => {
+  public update$: Observable<Action> = this.actions$.pipe(
+    ofType<LinkTypesAction.Update>(LinkTypesActionType.UPDATE),
+    mergeMap(action => {
       const linkTypeDto = LinkTypeConverter.toDto(action.payload.linkType);
 
       return this.linkTypeService.updateLinkType(action.payload.linkType.id, linkTypeDto).pipe(
@@ -114,7 +119,8 @@ export class LinkTypesEffects {
   );
 
   @Effect()
-  public updateFailure$: Observable<Action> = this.actions$.ofType<LinkTypesAction.UpdateFailure>(LinkTypesActionType.UPDATE_FAILURE).pipe(
+  public updateFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<LinkTypesAction.UpdateFailure>(LinkTypesActionType.UPDATE_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'link.type.update.fail', value: 'Failed to update link type'});
@@ -123,14 +129,16 @@ export class LinkTypesEffects {
   );
 
   @Effect()
-  public delete$: Observable<Action> = this.actions$.ofType(LinkTypesActionType.DELETE).pipe(
-    switchMap((action: LinkTypesAction.Delete) => this.linkTypeService.deleteLinkType(action.payload.linkTypeId)),
+  public delete$: Observable<Action> = this.actions$.pipe(
+    ofType<LinkTypesAction.Delete>(LinkTypesActionType.DELETE),
+    mergeMap(action => this.linkTypeService.deleteLinkType(action.payload.linkTypeId)),
     map(linkTypeId => new LinkTypesAction.DeleteSuccess({linkTypeId: linkTypeId})),
     catchError((error) => Observable.of(new LinkTypesAction.DeleteFailure({error: error})))
   );
 
   @Effect()
-  public deleteFailure$: Observable<Action> = this.actions$.ofType<LinkTypesAction.DeleteFailure>(LinkTypesActionType.DELETE_FAILURE).pipe(
+  public deleteFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<LinkTypesAction.DeleteFailure>(LinkTypesActionType.DELETE_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'link.type.delete.fail', value: 'Failed to delete link type'});

--- a/src/app/core/store/notifications/notifications.effects.ts
+++ b/src/app/core/store/notifications/notifications.effects.ts
@@ -18,11 +18,10 @@
  */
 
 import {Injectable} from '@angular/core';
-import {Actions, Effect} from '@ngrx/effects';
-import {Action, Store} from '@ngrx/store';
+import {Actions, Effect, ofType} from '@ngrx/effects';
+import {Store} from '@ngrx/store';
 import {I18n} from '@ngx-translate/i18n-polyfill';
 import {SnotifyButton} from 'ng-snotify';
-import {Observable} from 'rxjs/Observable';
 import {tap} from 'rxjs/operators';
 import {NotificationService} from '../../notifications/notification.service';
 import {AppState} from '../app.state';
@@ -32,8 +31,9 @@ import {NotificationsAction, NotificationsActionType} from './notifications.acti
 export class NotificationsEffects {
 
   @Effect({dispatch: false})
-  public confirm$: Observable<Action> = this.actions.ofType(NotificationsActionType.CONFIRM).pipe(
-    tap((action: NotificationsAction.Confirm) => {
+  public confirm$ = this.actions.pipe(
+    ofType<NotificationsAction.Confirm>(NotificationsActionType.CONFIRM),
+    tap(action => {
       const yesButtonText = this.i18n({id: 'button.yes', value: 'Yes'});
       const noButtonText = this.i18n({id: 'button.no', value: 'No'});
 
@@ -46,18 +46,21 @@ export class NotificationsEffects {
   );
 
   @Effect({dispatch: false})
-  public error$: Observable<Action> = this.actions.ofType(NotificationsActionType.ERROR).pipe(
-    tap((action: NotificationsAction.Error) => this.notificationService.error(action.payload.message))
+  public error$ = this.actions.pipe(
+    ofType<NotificationsAction.Error>(NotificationsActionType.ERROR),
+    tap(action => this.notificationService.error(action.payload.message))
   );
 
   @Effect({dispatch: false})
-  public success$: Observable<Action> = this.actions.ofType(NotificationsActionType.SUCCESS).pipe(
-    tap((action: NotificationsAction.Success) => this.notificationService.success(action.payload.message))
+  public success$ = this.actions.pipe(
+    ofType<NotificationsAction.Success>(NotificationsActionType.SUCCESS),
+    tap(action => this.notificationService.success(action.payload.message))
   );
 
   @Effect({dispatch: false})
-  public warning$: Observable<Action> = this.actions.ofType(NotificationsActionType.WARNING).pipe(
-    tap((action: NotificationsAction.Warning) => this.notificationService.warning(action.payload.message))
+  public warning$ = this.actions.pipe(
+    ofType<NotificationsAction.Warning>(NotificationsActionType.WARNING),
+    tap(action => this.notificationService.warning(action.payload.message))
   );
 
   constructor(private actions: Actions,

--- a/src/app/core/store/router/router.effects.ts
+++ b/src/app/core/store/router/router.effects.ts
@@ -20,7 +20,7 @@
 import {Location} from '@angular/common';
 import {Injectable} from '@angular/core';
 import {Router} from '@angular/router';
-import {Actions, Effect} from '@ngrx/effects';
+import {Actions, Effect, ofType} from '@ngrx/effects';
 import {map, tap} from 'rxjs/operators';
 import {RouterAction, RouterActionType} from './router.action';
 
@@ -28,18 +28,21 @@ import {RouterAction, RouterActionType} from './router.action';
 export class RouterEffects {
 
   @Effect({dispatch: false})
-  public navigate$ = this.actions$.ofType(RouterActionType.GO).pipe(
-    map((action: RouterAction.Go) => action.payload),
+  public navigate$ = this.actions$.pipe(
+    ofType<RouterAction.Go>(RouterActionType.GO),
+    map(action => action.payload),
     tap(({path, queryParams, extras}) => this.router.navigate(path, {queryParams, ...extras}))
   );
 
   @Effect({dispatch: false})
-  public navigateBack$ = this.actions$.ofType(RouterActionType.BACK).pipe(
+  public navigateBack$ = this.actions$.pipe(
+    ofType(RouterActionType.BACK),
     tap(() => this.location.back())
   );
 
   @Effect({dispatch: false})
-  public navigateForward$ = this.actions$.ofType(RouterActionType.FORWARD).pipe(
+  public navigateForward$ = this.actions$.pipe(
+    ofType(RouterActionType.FORWARD),
     tap(() => this.location.forward())
   );
 

--- a/src/app/core/store/smartdoc/smartdoc.effects.ts
+++ b/src/app/core/store/smartdoc/smartdoc.effects.ts
@@ -18,11 +18,11 @@
  */
 
 import {Injectable} from '@angular/core';
-import {Actions, Effect} from '@ngrx/effects';
+import {Actions, Effect, ofType} from '@ngrx/effects';
 import {Action, Store} from '@ngrx/store';
 import {I18n} from '@ngx-translate/i18n-polyfill';
 import {Observable} from 'rxjs/Observable';
-import {map, withLatestFrom, flatMap} from 'rxjs/operators';
+import {flatMap, map, withLatestFrom} from 'rxjs/operators';
 import {isNullOrUndefined} from 'util';
 import {SmartDocUtils} from '../../../view/perspectives/smartdoc/smartdoc.utils';
 import {AppState} from '../app.state';
@@ -36,7 +36,8 @@ import {SmartDocModel} from './smartdoc.model';
 export class SmartDocEffects {
 
   @Effect()
-  public addPart$: Observable<Action> = this.actions$.ofType<SmartDocAction.AddPart>(SmartDocActionType.ADD_PART).pipe(
+  public addPart$: Observable<Action> = this.actions$.pipe(
+    ofType<SmartDocAction.AddPart>(SmartDocActionType.ADD_PART),
     withLatestFrom(this.store$.select(selectViewSmartDocConfig)),
     map(([action, smartDocConfig]) => {
       const config = SmartDocEffects.modifyInnerSmartDoc(smartDocConfig, action.payload.partPath, innerSmartDoc => {
@@ -52,7 +53,8 @@ export class SmartDocEffects {
   );
 
   @Effect()
-  public updatePart$: Observable<Action> = this.actions$.ofType<SmartDocAction.UpdatePart>(SmartDocActionType.UPDATE_PART).pipe(
+  public updatePart$: Observable<Action> = this.actions$.pipe(
+    ofType<SmartDocAction.UpdatePart>(SmartDocActionType.UPDATE_PART),
     withLatestFrom(this.store$.select(selectViewSmartDocConfig)),
     map(([action, smartDocConfig]) => {
       const config = SmartDocEffects.modifyInnerSmartDoc(smartDocConfig, action.payload.partPath, innerSmartDoc => {
@@ -64,7 +66,8 @@ export class SmartDocEffects {
   );
 
   @Effect()
-  public removePart$: Observable<Action> = this.actions$.ofType<SmartDocAction.RemovePart>(SmartDocActionType.REMOVE_PART).pipe(
+  public removePart$: Observable<Action> = this.actions$.pipe(
+    ofType<SmartDocAction.RemovePart>(SmartDocActionType.REMOVE_PART),
     withLatestFrom(this.store$.select(selectViewSmartDocConfig)),
     flatMap(([action, smartDocConfig]) => {
       const config = SmartDocEffects.modifyInnerSmartDoc(smartDocConfig, action.payload.partPath, innerSmartDoc => {
@@ -75,14 +78,15 @@ export class SmartDocEffects {
       const actions: Action[] = [new ViewsAction.ChangeSmartDocConfig({config})];
       if (action.payload.last) {
         const part = SmartDocUtils.createEmptyTextPart();
-        actions.push(new SmartDocAction.AddPart({partPath: action.payload.partPath, part}))
+        actions.push(new SmartDocAction.AddPart({partPath: action.payload.partPath, part}));
       }
       return actions;
     })
   );
 
   @Effect()
-  public removePartConfirm$: Observable<Action> = this.actions$.ofType<SmartDocAction.RemovePartConfirm>(SmartDocActionType.REMOVE_PART_CONFIRM).pipe(
+  public removePartConfirm$: Observable<Action> = this.actions$.pipe(
+    ofType<SmartDocAction.RemovePartConfirm>(SmartDocActionType.REMOVE_PART_CONFIRM),
     map((action: SmartDocAction.RemovePartConfirm) => {
       const title = this.i18n({id: 'smartdoc.remove.part.dialog.title', value: 'Remove part'});
       const message = this.i18n({id: 'smartdoc.remove.part.dialog.message', value: 'Do you really want to remove this template part?'});
@@ -91,12 +95,13 @@ export class SmartDocEffects {
         title,
         message,
         action: new SmartDocAction.RemovePart(action.payload)
-      })
+      });
     })
   );
 
   @Effect()
-  public movePart$: Observable<Action> = this.actions$.ofType<SmartDocAction.MovePart>(SmartDocActionType.MOVE_PART).pipe(
+  public movePart$: Observable<Action> = this.actions$.pipe(
+    ofType<SmartDocAction.MovePart>(SmartDocActionType.MOVE_PART),
     withLatestFrom(this.store$.select(selectViewSmartDocConfig)),
     map(([action, smartDocConfig]) => {
       const config = SmartDocEffects.modifyInnerSmartDoc(smartDocConfig, action.payload.partPath, innerSmartDoc => {
@@ -108,7 +113,8 @@ export class SmartDocEffects {
   );
 
   @Effect()
-  public orderDocuments$: Observable<Action> = this.actions$.ofType<SmartDocAction.OrderDocuments>(SmartDocActionType.ORDER_DOCUMENTS).pipe(
+  public orderDocuments$: Observable<Action> = this.actions$.pipe(
+    ofType<SmartDocAction.OrderDocuments>(SmartDocActionType.ORDER_DOCUMENTS),
     withLatestFrom(this.store$.select(selectViewSmartDocConfig)),
     map(([action, smartDocConfig]) => {
       const config = SmartDocEffects.modifyInnerSmartDoc(smartDocConfig, action.payload.partPath, innerSmartDoc => {

--- a/src/app/core/store/tables/tables.effects.ts
+++ b/src/app/core/store/tables/tables.effects.ts
@@ -21,7 +21,7 @@ import {Injectable} from '@angular/core';
 import {Actions, Effect, ofType} from '@ngrx/effects';
 import {Action, Store} from '@ngrx/store';
 import {Observable} from 'rxjs/Observable';
-import {filter, first, flatMap, map, mergeMap, switchMap, withLatestFrom} from 'rxjs/operators';
+import {concatMap, filter, first, flatMap, map, mergeMap, switchMap, withLatestFrom} from 'rxjs/operators';
 import {splitAttributeId} from '../../../shared/utils/attribute.utils';
 import {AppState} from '../app.state';
 import {AttributeModel, CollectionModel} from '../collections/collection.model';
@@ -78,7 +78,7 @@ export class TablesEffects {
   @Effect()
   public destroyTable$: Observable<Action> = this.actions$.pipe(
     ofType<TablesAction.DestroyTable>(TablesActionType.DESTROY_TABLE),
-    switchMap(action => this.store$.select(selectTableById(action.payload.tableId)).pipe(
+    concatMap(action => this.store$.select(selectTableById(action.payload.tableId)).pipe(
       first()
     )),
     flatMap(table => {
@@ -95,15 +95,15 @@ export class TablesEffects {
   @Effect()
   public createPart$: Observable<Action> = this.actions$.pipe(
     ofType<TablesAction.CreatePart>(TablesActionType.CREATE_PART),
-    switchMap(action => this.store$.select(selectTableById(action.payload.tableId)).pipe(
+    mergeMap(action => this.store$.select(selectTableById(action.payload.tableId)).pipe(
       first(),
       map(table => ({action, table}))
     )),
-    switchMap(item => this.store$.select(selectLinkTypeById(item.action.payload.linkTypeId)).pipe(
+    mergeMap(item => this.store$.select(selectLinkTypeById(item.action.payload.linkTypeId)).pipe(
       first(),
       map(linkType => ({...item, linkType}))
     )),
-    switchMap(item => {
+    mergeMap(item => {
       const parts = item.table.parts;
       const lastPart = parts[parts.length - 1];
 
@@ -174,7 +174,7 @@ export class TablesEffects {
   @Effect()
   public splitColumn$: Observable<Action> = this.actions$.pipe(
     ofType<TablesAction.SplitColumn>(TablesActionType.SPLIT_COLUMN),
-    switchMap(action => this.store$.select(selectTableById(action.payload.cursor.tableId)).pipe(
+    mergeMap(action => this.store$.select(selectTableById(action.payload.cursor.tableId)).pipe(
       first(),
       mergeMap(table => {
         const part = table.parts[action.payload.cursor.partIndex];
@@ -291,7 +291,7 @@ export class TablesEffects {
   @Effect()
   public removeColumn$: Observable<Action> = this.actions$.pipe(
     ofType<TablesAction.RemoveColumn>(TablesActionType.REMOVE_COLUMN),
-    switchMap(action => this.store$.select(selectTableById(action.payload.cursor.tableId)).pipe(
+    mergeMap(action => this.store$.select(selectTableById(action.payload.cursor.tableId)).pipe(
       first(),
       map(table => ({action, table}))
     )),
@@ -310,7 +310,7 @@ export class TablesEffects {
   @Effect()
   public renameColumn$: Observable<Action> = this.actions$.pipe(
     ofType<TablesAction.RenameColumn>(TablesActionType.RENAME_COLUMN),
-    switchMap(action => this.store$.select(selectTableById(action.payload.cursor.tableId)).pipe(
+    mergeMap(action => this.store$.select(selectTableById(action.payload.cursor.tableId)).pipe(
       first(),
       map(table => ({action, table}))
     )),
@@ -349,7 +349,7 @@ export class TablesEffects {
   @Effect()
   public resizeColumn$: Observable<Action> = this.actions$.pipe(
     ofType<TablesAction.ResizeColumn>(TablesActionType.RESIZE_COLUMN),
-    switchMap(action => this.store$.select(selectTableById(action.payload.cursor.tableId)).pipe(
+    mergeMap(action => this.store$.select(selectTableById(action.payload.cursor.tableId)).pipe(
       first(),
       map(table => {
         const part: TablePart = table.parts[action.payload.cursor.partIndex];
@@ -368,7 +368,7 @@ export class TablesEffects {
   @Effect()
   public moveCursor$: Observable<Action> = this.actions$.pipe(
     ofType<TablesAction.MoveCursor>(TablesActionType.MOVE_CURSOR),
-    switchMap(action => this.store$.select(selectTableById(action.payload.cursor.tableId)).pipe(
+    concatMap(action => this.store$.select(selectTableById(action.payload.cursor.tableId)).pipe(
       first(),
       map(table => ({action, table}))
     )),

--- a/src/app/core/store/users/users.effects.ts
+++ b/src/app/core/store/users/users.effects.ts
@@ -18,11 +18,11 @@
  */
 
 import {Injectable} from '@angular/core';
-import {Actions, Effect} from '@ngrx/effects';
+import {Actions, Effect, ofType} from '@ngrx/effects';
 import {Action} from '@ngrx/store';
 import {I18n} from '@ngx-translate/i18n-polyfill';
 import {Observable} from 'rxjs/Observable';
-import {catchError, map, switchMap, tap} from 'rxjs/operators';
+import {catchError, map, mergeMap, tap} from 'rxjs/operators';
 import {UserService} from '../../rest';
 import {NotificationsAction} from '../notifications/notifications.action';
 import {UserConverter} from './user.converter';
@@ -32,8 +32,9 @@ import {UsersAction, UsersActionType} from './users.action';
 export class UsersEffects {
 
   @Effect()
-  public get$: Observable<Action> = this.actions$.ofType<UsersAction.Get>(UsersActionType.GET).pipe(
-    switchMap((action) => this.userService.getUsers(action.payload.organizationId).pipe(
+  public get$: Observable<Action> = this.actions$.pipe(
+    ofType<UsersAction.Get>(UsersActionType.GET),
+    mergeMap((action) => this.userService.getUsers(action.payload.organizationId).pipe(
       map(dtos => dtos.map(dto => UserConverter.fromDto(dto)))
     )),
     map(users => new UsersAction.GetSuccess({users: users})),
@@ -41,7 +42,8 @@ export class UsersEffects {
   );
 
   @Effect()
-  public getFailure$: Observable<Action> = this.actions$.ofType<UsersAction.GetFailure>(UsersActionType.GET_FAILURE).pipe(
+  public getFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<UsersAction.GetFailure>(UsersActionType.GET_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'users.get.fail', value: 'Failed to get users'});
@@ -50,8 +52,9 @@ export class UsersEffects {
   );
 
   @Effect()
-  public create$: Observable<Action> = this.actions$.ofType<UsersAction.Create>(UsersActionType.CREATE).pipe(
-    switchMap(action => {
+  public create$: Observable<Action> = this.actions$.pipe(
+    ofType<UsersAction.Create>(UsersActionType.CREATE),
+    mergeMap(action => {
       const userDto = UserConverter.toDto(action.payload.user);
 
       return this.userService.createUser(action.payload.organizationId, userDto).pipe(
@@ -63,7 +66,8 @@ export class UsersEffects {
   );
 
   @Effect()
-  public createFailure$: Observable<Action> = this.actions$.ofType<UsersAction.CreateFailure>(UsersActionType.CREATE_FAILURE).pipe(
+  public createFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<UsersAction.CreateFailure>(UsersActionType.CREATE_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'user.create.fail', value: 'Failed to create user'});
@@ -72,8 +76,9 @@ export class UsersEffects {
   );
 
   @Effect()
-  public update$: Observable<Action> = this.actions$.ofType<UsersAction.Update>(UsersActionType.UPDATE).pipe(
-    switchMap(action => {
+  public update$: Observable<Action> = this.actions$.pipe(
+    ofType<UsersAction.Update>(UsersActionType.UPDATE),
+    mergeMap(action => {
       const userDto = UserConverter.toDto(action.payload.user);
 
       return this.userService.updateUser(action.payload.organizationId, userDto.id, userDto).pipe(
@@ -85,7 +90,8 @@ export class UsersEffects {
   );
 
   @Effect()
-  public updateFailure$: Observable<Action> = this.actions$.ofType<UsersAction.UpdateFailure>(UsersActionType.UPDATE_FAILURE).pipe(
+  public updateFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<UsersAction.UpdateFailure>(UsersActionType.UPDATE_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'user.update.fail', value: 'Failed to update user'});
@@ -94,8 +100,9 @@ export class UsersEffects {
   );
 
   @Effect()
-  public delete$: Observable<Action> = this.actions$.ofType<UsersAction.Delete>(UsersActionType.DELETE).pipe(
-    switchMap(action => this.userService.deleteUser(action.payload.organizationId, action.payload.userId).pipe(
+  public delete$: Observable<Action> = this.actions$.pipe(
+    ofType<UsersAction.Delete>(UsersActionType.DELETE),
+    mergeMap(action => this.userService.deleteUser(action.payload.organizationId, action.payload.userId).pipe(
       map(() => action)
     )),
     map(action => new UsersAction.DeleteSuccess(action.payload)),
@@ -103,7 +110,8 @@ export class UsersEffects {
   );
 
   @Effect()
-  public deleteFailure$: Observable<Action> = this.actions$.ofType<UsersAction.DeleteFailure>(UsersActionType.DELETE_FAILURE).pipe(
+  public deleteFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<UsersAction.DeleteFailure>(UsersActionType.DELETE_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'user.delete.fail', value: 'Failed to delete user'});

--- a/src/app/core/store/views/views.effects.ts
+++ b/src/app/core/store/views/views.effects.ts
@@ -18,11 +18,11 @@
  */
 
 import {Injectable} from '@angular/core';
-import {Actions, Effect} from '@ngrx/effects';
+import {Actions, Effect, ofType} from '@ngrx/effects';
 import {Action, Store} from '@ngrx/store';
 import {I18n} from '@ngx-translate/i18n-polyfill';
 import {Observable} from 'rxjs/Observable';
-import {catchError, flatMap, map, skipWhile, switchMap, tap, withLatestFrom} from 'rxjs/operators';
+import {catchError, flatMap, map, mergeMap, skipWhile, tap, withLatestFrom} from 'rxjs/operators';
 import {isNullOrUndefined} from 'util';
 import {View} from '../../dto';
 import {SearchService, ViewService} from '../../rest';
@@ -40,8 +40,9 @@ import {selectViewsDictionary} from './views.state';
 export class ViewsEffects {
 
   @Effect()
-  public get: Observable<Action> = this.actions$.ofType<ViewsAction.Get>(ViewsActionType.GET).pipe(
-    switchMap((action) => {
+  public get: Observable<Action> = this.actions$.pipe(
+    ofType<ViewsAction.Get>(ViewsActionType.GET),
+    mergeMap((action) => {
       return this.searchService.searchViews(action.payload.query).pipe(
         map((dtos: View[]) => dtos.map(dto => ViewConverter.convertToModel(dto)))
       );
@@ -51,10 +52,11 @@ export class ViewsEffects {
   );
 
   @Effect()
-  public getByCode$: Observable<Action> = this.actions$.ofType<ViewsAction.GetByCode>(ViewsActionType.GET_BY_CODE).pipe(
+  public getByCode$: Observable<Action> = this.actions$.pipe(
+    ofType<ViewsAction.GetByCode>(ViewsActionType.GET_BY_CODE),
     withLatestFrom(this.store$.select(selectViewsDictionary)),
     skipWhile(([action, views]) => action.payload.viewCode in views),
-    switchMap(([action]) => this.viewService.getView(action.payload.viewCode).pipe(
+    mergeMap(([action]) => this.viewService.getView(action.payload.viewCode).pipe(
       skipWhile((dto: View) => isNullOrUndefined(dto)), // TODO can probably be removed once views are not stored in webstorage
       map((dto: View) => ViewConverter.convertToModel(dto))
     )),
@@ -63,7 +65,8 @@ export class ViewsEffects {
   );
 
   @Effect()
-  public getFailure$: Observable<Action> = this.actions$.ofType<ViewsAction.GetFailure>(ViewsActionType.GET_FAILURE).pipe(
+  public getFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<ViewsAction.GetFailure>(ViewsActionType.GET_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'views.get.fail', value: 'Failed to get views'});
@@ -72,8 +75,9 @@ export class ViewsEffects {
   );
 
   @Effect()
-  public create$: Observable<Action> = this.actions$.ofType<ViewsAction.Create>(ViewsActionType.CREATE).pipe(
-    switchMap(action => {
+  public create$: Observable<Action> = this.actions$.pipe(
+    ofType<ViewsAction.Create>(ViewsActionType.CREATE),
+    mergeMap(action => {
       const viewDto = ViewConverter.convertToDto(action.payload.view);
 
       return this.viewService.createView(viewDto).pipe(
@@ -85,7 +89,8 @@ export class ViewsEffects {
   );
 
   @Effect()
-  public createSuccess$: Observable<Action> = this.actions$.ofType(ViewsActionType.CREATE_SUCCESS).pipe(
+  public createSuccess$: Observable<Action> = this.actions$.pipe(
+    ofType(ViewsActionType.CREATE_SUCCESS),
     withLatestFrom(this.store$.select(selectWorkspace)),
     flatMap(([action, workspace]: [ViewsAction.CreateSuccess, Workspace]) => {
       const message = this.i18n({id: 'view.create.success', value: 'View has been created'});
@@ -97,7 +102,8 @@ export class ViewsEffects {
   );
 
   @Effect()
-  public createFailure$: Observable<Action> = this.actions$.ofType<ViewsAction.CreateFailure>(ViewsActionType.CREATE_FAILURE).pipe(
+  public createFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<ViewsAction.CreateFailure>(ViewsActionType.CREATE_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'view.create.fail', value: 'Failed to create view'});
@@ -106,8 +112,9 @@ export class ViewsEffects {
   );
 
   @Effect()
-  public update$: Observable<Action> = this.actions$.ofType<ViewsAction.Update>(ViewsActionType.UPDATE).pipe(
-    switchMap(action => {
+  public update$: Observable<Action> = this.actions$.pipe(
+    ofType<ViewsAction.Update>(ViewsActionType.UPDATE),
+    mergeMap(action => {
       const viewDto = ViewConverter.convertToDto(action.payload.view);
 
       return Observable.combineLatest(
@@ -122,7 +129,8 @@ export class ViewsEffects {
   );
 
   @Effect()
-  public updateSuccess$: Observable<Action> = this.actions$.ofType<ViewsAction.UpdateSuccess>(ViewsActionType.UPDATE_SUCCESS).pipe(
+  public updateSuccess$: Observable<Action> = this.actions$.pipe(
+    ofType<ViewsAction.UpdateSuccess>(ViewsActionType.UPDATE_SUCCESS),
     tap(action => {
       if (action.payload.nextAction) {
         this.store$.dispatch(action.payload.nextAction);
@@ -135,7 +143,8 @@ export class ViewsEffects {
   );
 
   @Effect()
-  public updateFailure$: Observable<Action> = this.actions$.ofType<ViewsAction.UpdateFailure>(ViewsActionType.UPDATE_FAILURE).pipe(
+  public updateFailure$: Observable<Action> = this.actions$.pipe(
+    ofType<ViewsAction.UpdateFailure>(ViewsActionType.UPDATE_FAILURE),
     tap(action => console.error(action.payload.error)),
     map(() => {
       const message = this.i18n({id: 'view.update.fail', value: 'Failed to update view'});

--- a/src/app/shared/search-box/input/suggestions/search-suggestions.component.ts
+++ b/src/app/shared/search-box/input/suggestions/search-suggestions.component.ts
@@ -20,7 +20,7 @@
 import {Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {Observable} from 'rxjs/Observable';
-import {catchError, debounceTime, map, startWith, switchMap, withLatestFrom} from 'rxjs/operators';
+import {catchError, debounceTime, map, mergeMap, startWith, switchMap, withLatestFrom} from 'rxjs/operators';
 import {Subject} from 'rxjs/Subject';
 import {Subscription} from 'rxjs/Subscription';
 import {Suggestions, SuggestionType} from '../../../../core/dto';
@@ -107,7 +107,7 @@ export class SearchSuggestionsComponent implements OnChanges, OnDestroy, OnInit 
       debounceTime(300),
       switchMap(text => this.retrieveSuggestions(text)),
       withLatestFrom(this.store.select(selectAllCollections)),
-      switchMap(([suggestions, collections]) => SuggestionsConverter.convertSuggestionsToQueryItems(suggestions, collections)),
+      mergeMap(([suggestions, collections]) => SuggestionsConverter.convertSuggestionsToQueryItems(suggestions, collections)),
       map(queryItems => this.filterViewQueryItems(queryItems)),
       map(queryItems => this.addFulltextSuggestion(queryItems)),
       map(queryItems => this.filterUsedQueryItems(queryItems)),

--- a/src/app/workspace/organization/organization-settings.guard.ts
+++ b/src/app/workspace/organization/organization-settings.guard.ts
@@ -22,7 +22,7 @@ import {ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot} from '
 import {Store} from '@ngrx/store';
 import {I18n} from '@ngx-translate/i18n-polyfill';
 import {Observable} from 'rxjs/Observable';
-import {switchMap} from 'rxjs/operators';
+import {mergeMap} from 'rxjs/operators';
 import {isNullOrUndefined} from 'util';
 import {AppState} from '../../core/store/app.state';
 import {GroupsAction} from '../../core/store/groups/groups.action';
@@ -49,7 +49,7 @@ export class OrganizationSettingsGuard implements CanActivate {
     const organizationCode = next.paramMap.get('organizationCode');
 
     return this.workspaceService.getOrganizationFromStoreOrApi(organizationCode).pipe(
-      switchMap(organization => {
+      mergeMap(organization => {
         if (isNullOrUndefined(organization)) {
           this.dispatchErrorActionsNotExist();
           return Observable.of(false);
@@ -69,7 +69,6 @@ export class OrganizationSettingsGuard implements CanActivate {
     return organization.permissions && organization.permissions.users.length === 1
       && organization.permissions.users[0].roles.some(r => r === Role.Manage.toString());
   }
-
 
   private dispatchErrorActionsNotExist() {
     const message = this.i18n({id: 'organization.not.exist', value: 'Organization does not exist'});

--- a/src/app/workspace/workspace.service.ts
+++ b/src/app/workspace/workspace.service.ts
@@ -21,8 +21,9 @@ import {Injectable} from '@angular/core';
 
 import {Store} from '@ngrx/store';
 import {Observable} from 'rxjs/Observable';
-import {catchError, map, switchMap, take, tap} from 'rxjs/operators';
-import {isNullOrUndefined} from "util";
+import {catchError, map, mergeMap, take, tap} from 'rxjs/operators';
+import {isNullOrUndefined} from 'util';
+import {OrganizationService, ProjectService} from '../core/rest';
 import {AppState} from '../core/store/app.state';
 import {OrganizationConverter} from '../core/store/organizations/organization.converter';
 import {OrganizationModel} from '../core/store/organizations/organization.model';
@@ -32,7 +33,6 @@ import {ProjectConverter} from '../core/store/projects/project.converter';
 import {ProjectModel} from '../core/store/projects/project.model';
 import {ProjectsAction} from '../core/store/projects/projects.action';
 import {selectAllProjects} from '../core/store/projects/projects.state';
-import {OrganizationService, ProjectService} from '../core/rest';
 
 @Injectable()
 export class WorkspaceService {
@@ -44,7 +44,7 @@ export class WorkspaceService {
 
   public getOrganizationFromStoreOrApi(code: string): Observable<OrganizationModel> {
     return this.getOrganizationFromStore(code).pipe(
-      switchMap(organization => {
+      mergeMap(organization => {
         if (!isNullOrUndefined(organization)) {
           return Observable.of(organization);
         }
@@ -73,7 +73,7 @@ export class WorkspaceService {
 
   public getProjectFromStoreOrApi(orgCode: string, orgId: string, projCode: string): Observable<ProjectModel> {
     return this.getProjectFromStore(projCode).pipe(
-      switchMap(project => {
+      mergeMap(project => {
         if (!isNullOrUndefined(project)) {
           return Observable.of(project);
         }


### PR DESCRIPTION
We should never use `switchMap` operator when calling remote services. See [this article](https://blog.angularindepth.com/switchmap-bugs-b6de69155524) for more details.