### PR TITLE
Fix Redux DevTools freezing #LMR-797

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -19,11 +19,12 @@
 
 import {NgModule} from '@angular/core';
 import {RouterModule, Routes} from '@angular/router';
-import {StoreRouterConnectingModule} from '@ngrx/router-store';
+import {RouterStateSerializer, StoreRouterConnectingModule} from '@ngrx/router-store';
 import {Angulartics2Module} from 'angulartics2';
 import {Angulartics2GoogleAnalytics} from 'angulartics2/ga';
 import {PageNotFoundGuard} from './core/guards/page-not-found.guard';
 import {HomeComponent} from './core/home.component';
+import {LumeerRouterStateSerializer} from './core/store/router/lumeer-router-state-serializer';
 
 const appRoutes: Routes = [
   {
@@ -54,7 +55,13 @@ export const angularticsSettings = {
     StoreRouterConnectingModule,
     Angulartics2Module.forRoot([Angulartics2GoogleAnalytics], angularticsSettings)
   ],
-  exports: [RouterModule]
+  exports: [RouterModule],
+  providers: [
+    {
+      provide: RouterStateSerializer,
+      useClass: LumeerRouterStateSerializer
+    }
+  ]
 })
 export class AppRoutingModule {
 }

--- a/src/app/core/store/app.state.ts
+++ b/src/app/core/store/app.state.ts
@@ -26,6 +26,7 @@ import {initialLinkTypesState, LinkTypesState} from './link-types/link-types.sta
 import {initialNavigationState, NavigationState} from './navigation/navigation.state';
 import {initialOrganizationsState, OrganizationsState} from './organizations/organizations.state';
 import {initialProjectsState, ProjectsState} from './projects/projects.state';
+import {RouterStateUrl} from './router/lumeer-router-state-serializer';
 import {initialUsersState, UsersState} from './users/users.state';
 import {initialViewsState, ViewsState} from './views/views.state';
 
@@ -39,7 +40,7 @@ export interface AppState {
   navigation: NavigationState;
   organizations: OrganizationsState;
   projects: ProjectsState;
-  router: RouterReducerState;
+  router: RouterReducerState<RouterStateUrl>;
   users: UsersState;
   views: ViewsState;
 

--- a/src/app/core/store/navigation/navigation.reducer.ts
+++ b/src/app/core/store/navigation/navigation.reducer.ts
@@ -19,29 +19,26 @@
 
 import {ROUTER_CANCEL, ROUTER_NAVIGATION, RouterCancelAction, RouterNavigationAction} from '@ngrx/router-store';
 import {perspectivesMap} from '../../../view/perspectives/perspective';
-import {QueryConverter} from './query.converter';
-import {RouteFinder} from '../../../shared/utils/route-finder';
+import {RouterStateUrl} from '../router/lumeer-router-state-serializer';
 import {NavigationState} from './navigation.state';
+import {QueryConverter} from './query.converter';
 
-function onRouterNavigation(state: NavigationState, action: RouterNavigationAction): NavigationState {
-  const route = action.payload.routerState.root;
-  // TODO harvest params, queryParams, and data from all route nodes in the tree
-  const params = RouteFinder.getFirstChildRouteWithParams(route).paramMap;
-  const queryParams = route.queryParamMap;
+function onRouterNavigation(state: NavigationState, action: RouterNavigationAction<RouterStateUrl>): NavigationState {
+  const {data, params, queryParams, url} = action.payload.routerState;
 
-  const linkCollectionIds = queryParams.get('linkCollectionIds');
+  const linkCollectionIds = queryParams['linkCollectionIds'];
 
   return {
-    query: QueryConverter.fromString(queryParams.get('query')),
+    query: QueryConverter.fromString(queryParams['query']),
     workspace: {
-      organizationCode: params.get('organizationCode'),
-      projectCode: params.get('projectCode'),
-      collectionId: params.get('collectionId'),
-      viewCode: params.get('vc')
+      organizationCode: params['organizationCode'],
+      projectCode: params['projectCode'],
+      collectionId: params['collectionId'],
+      viewCode: params['vc']
     },
-    perspective: perspectivesMap[extractPerspectiveIdFromUrl(action.payload.routerState.url)],
-    searchBoxHidden: RouteFinder.getDeepestChildRoute(route).data['searchBoxHidden'],
-    viewName: queryParams.get('viewName'),
+    perspective: perspectivesMap[extractPerspectiveIdFromUrl(url)],
+    searchBoxHidden: data['searchBoxHidden'],
+    viewName: queryParams['viewName'],
     linkCollectionIds: linkCollectionIds ? linkCollectionIds.split(',') : null
   };
 }
@@ -56,7 +53,7 @@ function onRouterCancel(state: NavigationState, action: RouterCancelAction<Navig
   return (action as RouterCancelAction<NavigationState>).payload.storeState;
 }
 
-export function navigationReducer(state: NavigationState, action: RouterNavigationAction | RouterCancelAction<NavigationState>): NavigationState {
+export function navigationReducer(state: NavigationState, action: RouterNavigationAction<RouterStateUrl> | RouterCancelAction<NavigationState>): NavigationState {
   switch (action.type) {
     case ROUTER_NAVIGATION:
       return onRouterNavigation(state, action);

--- a/src/app/core/store/router/lumeer-router-state-serializer.ts
+++ b/src/app/core/store/router/lumeer-router-state-serializer.ts
@@ -1,0 +1,55 @@
+/*
+ * Lumeer: Modern Data Definition and Processing Platform
+ *
+ * Copyright (C) since 2017 Answer Institute, s.r.o. and/or its affiliates.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {Params, RouterStateSnapshot} from '@angular/router';
+import {Data} from '@angular/router/src/config';
+import {RouterStateSerializer} from '@ngrx/router-store';
+
+export interface RouterStateUrl {
+  url: string;
+  params: Params;
+  queryParams: Params;
+  data: Data;
+}
+
+export class LumeerRouterStateSerializer implements RouterStateSerializer<RouterStateUrl> {
+
+  public serialize(routerState: RouterStateSnapshot): RouterStateUrl {
+    let route = routerState.root;
+
+    const params: Params = {};
+    const queryParams: Params = {};
+
+    while (route.firstChild) {
+      for (const param in route.params) {
+        params[param] = route.params[param];
+      }
+      for (const queryParam in route.queryParams) {
+        queryParams[queryParam] = route.queryParams[queryParam];
+      }
+      route = route.firstChild;
+    }
+
+    const {url} = routerState;
+    const {data} = route;
+
+    return {url, params, queryParams, data};
+  }
+
+}


### PR DESCRIPTION
Have you ever wondered why Redux DevTools are often freezing? Here is the answer:

Angular router classes create a complicated hierarchies with many cyclic references. Redux DevTools always try to serialize the content of the store and they go into the depth. The result was 2GB RAM taken by Redux DevTools and the eventual crash of the extension.

See [this NgRx issue](https://github.com/ngrx/platform/issues/97) and [this section of the documention](https://github.com/ngrx/platform/blob/master/docs/router-store/api.md#custom-router-state-serializer).