### PR TITLE
Fix table perspective performance problems #LMR-898

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -62,6 +62,9 @@
     "component": {
       "spec": false
     },
+    "pipe": {
+      "spec": false
+    },
     "schematics": {
       "collection": "@ngrx/schematics"
     }

--- a/src/app/core/store/collections/collections.state.ts
+++ b/src/app/core/store/collections/collections.state.ts
@@ -20,6 +20,7 @@
 import {createEntityAdapter, EntityState} from '@ngrx/entity';
 import {createSelector} from '@ngrx/store';
 import {AppState} from '../app.state';
+import {selectLinkTypeById} from '../link-types/link-types.state';
 import {selectQuery, selectWorkspace} from '../navigation/navigation.state';
 import {CollectionModel} from './collection.model';
 
@@ -53,5 +54,11 @@ export const selectCollectionByWorkspace = createSelector(selectCollectionsDicti
 });
 
 export const selectCollectionById = (id: string) => createSelector(selectCollectionsDictionary, collectionsDictionary => collectionsDictionary[id]);
+
+export const selectCollectionsByLinkType = (linkTypeId: string) => createSelector(
+  selectCollectionsDictionary, selectLinkTypeById(linkTypeId), (collectionsMap, linkType) => {
+    return linkType.collectionIds.map(id => collectionsMap[id]);
+  }
+);
 
 export const selectCollectionNames = createSelector(selectCollectionsState, (state: CollectionsState) => state.collectionNames);

--- a/src/app/core/store/tables/table-cursor.ts
+++ b/src/app/core/store/tables/table-cursor.ts
@@ -369,9 +369,9 @@ export function isTableColumnSubPath(parent: TableHeaderCursor, child: TableHead
 export function areTableBodyCursorsEqual(cursor1: TableBodyCursor, cursor2: TableBodyCursor): boolean {
   return cursor1 && cursor2
     && cursor1.tableId === cursor2.tableId
-    && deepArrayEquals(cursor1.rowPath, cursor2.rowPath)
     && cursor1.partIndex === cursor2.partIndex
-    && cursor1.columnIndex === cursor2.columnIndex;
+    && cursor1.columnIndex === cursor2.columnIndex
+    && deepArrayEquals(cursor1.rowPath, cursor2.rowPath);
 }
 
 export function findTableColumnWithCursor(table: TableModel, partIndex: number, attributeName: string): { column: TableCompoundColumn, cursor: TableHeaderCursor } {

--- a/src/app/core/store/tables/table.model.ts
+++ b/src/app/core/store/tables/table.model.ts
@@ -20,6 +20,7 @@
 export const DEFAULT_TABLE_ID = 'default';
 
 export const DEFAULT_COLUMN_WIDTH = 100;
+export const DEFAULT_ROW_NUMBER_WIDTH = 40;
 
 export interface TableModel {
 

--- a/src/app/core/store/tables/tables.action.ts
+++ b/src/app/core/store/tables/tables.action.ts
@@ -63,7 +63,7 @@ export enum TablesActionType {
   EXPAND_ROWS = '[Tables] Expand Rows',
   COLLAPSE_ROWS = '[Tables] Collapse Rows',
 
-  EDIT_CELL = '[Tables] Edit Cell',
+  EDIT_SELECTED_CELL = '[Tables] Edit Selected Cell',
   COPY_CELL = '[Tables] Copy Cell',
   PASTE_CELL = '[Tables] Paste Cell',
   MOVE_CELL = '[Tables] Move Cell',
@@ -71,7 +71,7 @@ export enum TablesActionType {
   SET_CURSOR = '[Tables] Set Cursor',
   MOVE_CURSOR = '[Tables] Move Cursor',
 
-  SET_EDITED_ATTRIBUTE = '[Tables] Set Edited Document',
+  SET_EDITED_ATTRIBUTE = '[Tables] Set Edited Attribute',
 
   ADD_FUNCTION = '[Tables] Add Function',
   REMOVE_FUNCTION = '[Tables] Remove Function',
@@ -256,7 +256,14 @@ export namespace TablesAction {
   export class MoveCursor implements Action {
     public readonly type = TablesActionType.MOVE_CURSOR;
 
-    public constructor(public payload: { cursor: TableCursor, direction: Direction }) {
+    public constructor(public payload: { direction: Direction }) {
+    }
+  }
+
+  export class EditSelectedCell implements Action {
+    public readonly type = TablesActionType.EDIT_SELECTED_CELL;
+
+    public constructor(public payload: { letter?: string }) {
     }
   }
 
@@ -275,5 +282,5 @@ export namespace TablesAction {
     ReplaceRows | AddRows | AddLinkedRows | RemoveRow |
     CollapseRows | ExpandRows |
     SetCursor | MoveCursor |
-    SetEditedAttribute;
+    EditSelectedCell | SetEditedAttribute;
 }

--- a/src/app/core/store/tables/tables.state.ts
+++ b/src/app/core/store/tables/tables.state.ts
@@ -19,7 +19,7 @@
 
 import {createEntityAdapter, EntityState} from '@ngrx/entity';
 import {createFeatureSelector, createSelector} from '@ngrx/store';
-import {TableCursor} from './table-cursor';
+import {areTableBodyCursorsEqual, areTableHeaderCursorsEqual, TableCursor} from './table-cursor';
 import {TableModel} from './table.model';
 import {filterLeafColumns} from './table.utils';
 
@@ -34,7 +34,8 @@ export interface TablesState extends EntityState<TableModel> {
 
 export interface EditedAttribute {
 
-  documentId: string;
+  documentId?: string;
+  linkInstanceId?: string;
   attributeId: string;
 
 }
@@ -55,7 +56,21 @@ export const selectTableById = (tableId: string) =>
   createSelector(selectTablesDictionary, tablesDictionary => tablesDictionary[tableId]);
 
 export const selectTableCursor = createSelector(selectTablesState, state => state.cursor);
+export const selectTableCursorSelected = (cursor: TableCursor) => createSelector(selectTableCursor, selectedCursor => {
+  if (cursor.columnPath) {
+    return areTableHeaderCursorsEqual(selectedCursor, cursor);
+  } else {
+    return areTableBodyCursorsEqual(selectedCursor, cursor);
+  }
+});
+
 export const selectEditedAttribute = createSelector(selectTablesState, state => state.editedAttribute);
+export const selectAffected = (attribute: EditedAttribute) => createSelector(selectEditedAttribute, editedAttribute => {
+  return attribute && editedAttribute &&
+    attribute.documentId === editedAttribute.documentId &&
+    attribute.linkInstanceId === editedAttribute.linkInstanceId &&
+    attribute.attributeId === editedAttribute.attributeId;
+});
 
 export const selectTablePart = (tableId: string, partIndex: number) =>
   createSelector(selectTableById(tableId), table => table ? table.parts[partIndex] : null);

--- a/src/app/shared/pipes/colors.pipe.ts
+++ b/src/app/shared/pipes/colors.pipe.ts
@@ -1,0 +1,12 @@
+import {Pipe, PipeTransform} from '@angular/core';
+
+@Pipe({
+  name: 'colors'
+})
+export class ColorsPipe implements PipeTransform {
+
+  public transform(entities: { color: string }[]): string[] {
+    return entities.map(entity => entity.color);
+  }
+
+}

--- a/src/app/shared/pipes/icons.pipe.ts
+++ b/src/app/shared/pipes/icons.pipe.ts
@@ -1,0 +1,12 @@
+import {Pipe, PipeTransform} from '@angular/core';
+
+@Pipe({
+  name: 'icons'
+})
+export class IconsPipe implements PipeTransform {
+
+  public transform(entities: { icon: string }[]): string[] {
+    return entities.map(entity => entity.icon);
+  }
+
+}

--- a/src/app/shared/pipes/pipes.module.ts
+++ b/src/app/shared/pipes/pipes.module.ts
@@ -1,0 +1,26 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {ColorsPipe} from './colors.pipe';
+import {PrefixPipe} from './prefix.pipe';
+import {IconsPipe} from './icons.pipe';
+import {PixelPipe} from './pixel.pipe';
+
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  declarations: [
+    PixelPipe,
+    IconsPipe,
+    ColorsPipe,
+    PrefixPipe
+  ],
+  exports: [
+    PixelPipe,
+    IconsPipe,
+    ColorsPipe,
+    PrefixPipe
+  ]
+})
+export class PipesModule {
+}

--- a/src/app/shared/pipes/pixel.pipe.ts
+++ b/src/app/shared/pipes/pixel.pipe.ts
@@ -1,0 +1,12 @@
+import {Pipe, PipeTransform} from '@angular/core';
+
+@Pipe({
+  name: 'pixel'
+})
+export class PixelPipe implements PipeTransform {
+
+  public transform(length: number): string {
+    return `${length}px`;
+  }
+
+}

--- a/src/app/shared/pipes/prefix.pipe.ts
+++ b/src/app/shared/pipes/prefix.pipe.ts
@@ -1,0 +1,12 @@
+import {Pipe, PipeTransform} from '@angular/core';
+
+@Pipe({
+  name: 'prefix'
+})
+export class PrefixPipe implements PipeTransform {
+
+  public transform(value: string, prefix: string): string {
+    return prefix + value;
+  }
+
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -23,19 +23,19 @@ import {FormsModule} from '@angular/forms';
 import {RouterModule} from '@angular/router';
 import {CommentsComponent} from './comments/comments.component';
 import {DragAndDropModule} from './drag-and-drop/drag-and-drop.module';
+import {InputModule} from './input/input.module';
 import {LinksComponent} from './links/links.component';
-
 import {PerspectiveDirective} from './perspective.directive';
 import {PickerModule} from './picker/picker.module';
+import {PipesModule} from './pipes/pipes.module';
+import {RemovePlaceholderOnFocusDirective} from './placeholder/remove-placeholder-on-focus';
+import {PostItCollectionsModule} from './post-it-collections/post-it-collections.module';
+import {ResourceHeaderComponent} from './resource/header/resource-header.component';
 import {SearchBoxModule} from './search-box/search-box.module';
 import {SizeSliderComponent} from './slider/size-slider.component';
-import {RemovePlaceholderOnFocusDirective} from './placeholder/remove-placeholder-on-focus';
 import {SliderComponent} from './slider/slider.component';
-import {UsersModule} from "./users/users.module";
-import {TagModule} from "./tag/tag.module";
-import {InputModule} from "./input/input.module";
-import {ResourceHeaderComponent} from './resource/header/resource-header.component';
-import {PostItCollectionsModule} from './post-it-collections/post-it-collections.module';
+import {TagModule} from './tag/tag.module';
+import {UsersModule} from './users/users.module';
 
 @NgModule({
   imports: [
@@ -48,7 +48,8 @@ import {PostItCollectionsModule} from './post-it-collections/post-it-collections
     UsersModule,
     TagModule,
     InputModule,
-    PostItCollectionsModule
+    PostItCollectionsModule,
+    PipesModule
   ],
   declarations: [
     SizeSliderComponent,

--- a/src/app/view/perspectives/table2/body/rows/row/cell-group/cell/collapsed-cell/table-collapsed-cell.component.html
+++ b/src/app/view/perspectives/table2/body/rows/row/cell-group/cell/collapsed-cell/table-collapsed-cell.component.html
@@ -2,8 +2,8 @@
      [class.affected]="affected$ | async"
      [class.selected]="selected"
      [style.cursor]="'default'"
-     [title]="values()"
+     [title]="values"
      class="h-100 p-1 text-nowrap overflow-hidden"
      tabindex="0">
-  {{values()}}
+  {{values}}
 </div>

--- a/src/app/view/perspectives/table2/body/rows/row/cell-group/cell/data-cell/table-data-cell.component.html
+++ b/src/app/view/perspectives/table2/body/rows/row/cell-group/cell/data-cell/table-data-cell.component.html
@@ -1,15 +1,15 @@
 <table-editable-cell [affected]="affected$ | async"
-                     [contextMenu]="contextMenuElement()"
+                     [contextMenu]="contextMenuComponent?.contextMenu"
                      [readonly]="!selected"
                      [selected]="selected"
-                     [value]="value()"
+                     [value]="value"
                      (valueChange)="onValueChange($event)"
                      (editStart)="onEditStart()"
                      (editEnd)="onEditEnd($event)"
                      class="d-block h-100">
 </table-editable-cell>
 
-<table-data-cell-suggestions *ngIf="suggestionsEnabled()"
+<table-data-cell-suggestions *ngIf="!(cursor | isFirstPart) && !((document | entityCreated) || (linkInstance | entityCreated)) && editableCellComponent?.edited"
                              [column]="column"
                              [cursor]="cursor"
                              [table]="table"
@@ -19,7 +19,7 @@
 
 <table-data-cell-menu *ngIf="selected"
                       [cursor]="cursor"
-                      [created]="isCreated()"
+                      [created]="(document | entityCreated) || (linkInstance | entityCreated)"
                       (edit)="onEdit()"
                       (addRow)="onAddRow($event)"
                       (removeRow)="onRemoveRow()"

--- a/src/app/view/perspectives/table2/body/rows/row/cell-group/cell/table-cell.component.html
+++ b/src/app/view/perspectives/table2/body/rows/row/cell-group/cell/table-cell.component.html
@@ -1,23 +1,22 @@
-<div [style.width]="width()"
-     (keydown)="onKeyDown($event)"
-     (mousedown)="onMouseDown()"
+<div [style.width]="column | columnWidth | pixel"
+     (mousedown)="onMouseDown($event)"
      class="table-border-right table-border-bottom h-100">
-  <ng-container *ngIf="isSingleColumn()">
-    <table-data-cell *ngIf="!isCollapsed()"
+  <ng-container *ngIf="column | isSingleColumn">
+    <table-data-cell *ngIf="!collapsed"
                      [column]="column"
                      [cursor]="cursor"
                      [document]="documents ? documents[0] : null"
                      [linkInstance]="linkInstances ? linkInstances[0] : null"
-                     [selected]="selected"
+                     [selected]="selected$ | async"
                      [table]="table"
                      class="d-block h-100">
     </table-data-cell>
-    <table-collapsed-cell *ngIf="isCollapsed()"
+    <table-collapsed-cell *ngIf="collapsed"
                           [column]="column"
                           [cursor]="cursor"
                           [documents]="documents"
                           [linkInstances]="linkInstances"
-                          [selected]="selected"
+                          [selected]="selected$ | async"
                           class="d-block h-100">
     </table-collapsed-cell>
   </ng-container>

--- a/src/app/view/perspectives/table2/body/rows/row/cell-group/table-cell-group.component.html
+++ b/src/app/view/perspectives/table2/body/rows/row/cell-group/table-cell-group.component.html
@@ -1,8 +1,7 @@
 <div class="d-flex h-100">
-  <!-- TODO track by column attribute -->
-  <table-cell *ngFor="let column of columns$ | async; let columnIndex = index"
+  <table-cell *ngFor="let column of columns$ | async; trackBy: trackByAttributeIds; let columnIndex = index"
               [column]="column"
-              [cursor]="createColumnCursor(columnIndex)"
+              [cursor]="cursor | columnCursor:columnIndex"
               [documents]="documents"
               [linkInstances]="linkInstances"
               [table]="table">

--- a/src/app/view/perspectives/table2/body/rows/row/cell-group/table-cell-group.component.ts
+++ b/src/app/view/perspectives/table2/body/rows/row/cell-group/table-cell-group.component.ts
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {Component, Input, OnDestroy, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, OnDestroy, OnInit} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {Observable} from 'rxjs/Observable';
 import {Subscription} from 'rxjs/Subscription';
@@ -27,13 +27,14 @@ import {selectDocumentsByIds} from '../../../../../../../core/store/documents/do
 import {LinkInstanceModel} from '../../../../../../../core/store/link-instances/link-instance.model';
 import {selectLinkInstancesByIds} from '../../../../../../../core/store/link-instances/link-instances.state';
 import {TableBodyCursor} from '../../../../../../../core/store/tables/table-cursor';
-import {TableColumn, TableModel, TableRow} from '../../../../../../../core/store/tables/table.model';
+import {TableColumn, TableColumnType, TableCompoundColumn, TableHiddenColumn, TableModel, TableRow} from '../../../../../../../core/store/tables/table.model';
 import {selectTablePartLeafColumns} from '../../../../../../../core/store/tables/tables.state';
 
 @Component({
   selector: 'table-cell-group',
   templateUrl: './table-cell-group.component.html',
-  styleUrls: ['./table-cell-group.component.scss']
+  styleUrls: ['./table-cell-group.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class TableCellGroupComponent implements OnInit, OnDestroy {
 
@@ -94,8 +95,14 @@ export class TableCellGroupComponent implements OnInit, OnDestroy {
     this.subscriptions.unsubscribe();
   }
 
-  public createColumnCursor(columnIndex: number): TableBodyCursor {
-    return {...this.cursor, columnIndex};
+  public trackByAttributeIds(index: number, column: TableColumn): string {
+    if (column.type === TableColumnType.COMPOUND) {
+      const {parent} = column as TableCompoundColumn;
+      return parent.attributeId || parent.attributeName;
+    }
+    if (column.type === TableColumnType.HIDDEN) {
+      return (column as TableHiddenColumn).attributeIds.join('-');
+    }
   }
 
 }

--- a/src/app/view/perspectives/table2/body/rows/row/link-cell/table-link-cell.component.html
+++ b/src/app/view/perspectives/table2/body/rows/row/link-cell/table-link-cell.component.html
@@ -1,15 +1,15 @@
 <div class="table-border-right table-border-bottom h-100 p-1">
-  <div [style.width]="width()"
+  <div [style.width]="'30px'"
        [class.striped]="striped"
        class="link-cell h-100">
-    <a *ngIf="expendable()"
+    <a *ngIf="row | expandable"
        (click)="onExpand()"
        (keyup.enter)="onExpand()"
        class="d-flex h-100 m-0"
        title="Expand" i18n-title="@@table.link.expand">
       <i class="fa fa-expand m-auto"></i>
     </a>
-    <a *ngIf="collapsible()"
+    <a *ngIf="row | collapsible"
        (click)="onCollapse()"
        (keyup.enter)="onCollapse()"
        class="d-flex h-100 m-0"

--- a/src/app/view/perspectives/table2/body/rows/row/link-cell/table-link-cell.component.ts
+++ b/src/app/view/perspectives/table2/body/rows/row/link-cell/table-link-cell.component.ts
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {AppState} from '../../../../../../../core/store/app.state';
 import {TableBodyCursor} from '../../../../../../../core/store/tables/table-cursor';
@@ -27,7 +27,8 @@ import {TablesAction} from '../../../../../../../core/store/tables/tables.action
 @Component({
   selector: 'table-link-cell',
   templateUrl: './table-link-cell.component.html',
-  styleUrls: ['./table-link-cell.component.scss']
+  styleUrls: ['./table-link-cell.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class TableLinkCellComponent {
 
@@ -46,28 +47,12 @@ export class TableLinkCellComponent {
   public constructor(private store: Store<AppState>) {
   }
 
-  public collapsible(): boolean {
-    return this.row.linkedRows && this.row.linkedRows.length > 1;
-  }
-
-  public expendable(): boolean {
-    if (!this.row.linkedRows || this.row.linkedRows.length !== 1) {
-      return false;
-    }
-    const [row] = this.row.linkedRows;
-    return (row.documentIds && row.documentIds.length > 1) || (row.linkInstanceIds && row.linkInstanceIds.length > 1);
-  }
-
   public onExpand() {
     this.store.dispatch(new TablesAction.ExpandRows({cursor: this.cursor}));
   }
 
   public onCollapse() {
     this.store.dispatch(new TablesAction.CollapseRows({cursor: this.cursor}));
-  }
-
-  public width(): string {
-    return `30px`;
   }
 
 }

--- a/src/app/view/perspectives/table2/body/rows/row/row-numbers/table-row-numbers.component.html
+++ b/src/app/view/perspectives/table2/body/rows/row/row-numbers/table-row-numbers.component.html
@@ -1,8 +1,8 @@
 <div class="d-flex flex-column">
-  <div *ngFor="let rowIndex of rowIndexes()"
+  <div *ngFor="let rowIndex of rowIndexes"
        [class.border-top]="rowIndex > 0"
        [class.border-white]="rowIndex > 0"
-       [style.width]="rowNumberWidth()"
+       [style.width]="table | rowNumberWidth"
        class="row-number p-1 text-secondary text-right">
   </div>
 </div>

--- a/src/app/view/perspectives/table2/body/rows/row/row-numbers/table-row-numbers.component.ts
+++ b/src/app/view/perspectives/table2/body/rows/row/row-numbers/table-row-numbers.component.ts
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, OnChanges, SimpleChanges} from '@angular/core';
 import {TableBodyCursor} from '../../../../../../../core/store/tables/table-cursor';
 import {TableModel, TableRow} from '../../../../../../../core/store/tables/table.model';
 import {calculateRowNumber, countLinkedRows} from '../../../../../../../core/store/tables/table.utils';
@@ -27,7 +27,7 @@ import {calculateRowNumber, countLinkedRows} from '../../../../../../../core/sto
   templateUrl: './table-row-numbers.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class TableRowNumbersComponent {
+export class TableRowNumbersComponent implements OnChanges {
 
   @Input()
   public table: TableModel;
@@ -37,6 +37,15 @@ export class TableRowNumbersComponent {
 
   @Input()
   public row: TableRow;
+
+  public rowIndexes: number[] = [];
+
+  public ngOnChanges(changes: SimpleChanges): void {
+    if (changes.row && this.row) {
+      const rowsCount = countLinkedRows(this.row);
+      this.rowIndexes = Array.from(Array(rowsCount).keys());
+    }
+  }
 
   public rowNumberWidth(): string {
     return `${this.table.rowNumberWidth}px`;
@@ -51,11 +60,6 @@ export class TableRowNumbersComponent {
     const rowsCount = countLinkedRows(this.row);
     const indexes = Array.from(Array(rowsCount).keys());
     return indexes.map(index => firstRowNumber + index);
-  }
-
-  public rowIndexes(): number[] {
-    const rowsCount = countLinkedRows(this.row);
-    return Array.from(Array(rowsCount).keys());
   }
 
 }

--- a/src/app/view/perspectives/table2/body/rows/row/table-row.component.html
+++ b/src/app/view/perspectives/table2/body/rows/row/table-row.component.html
@@ -1,25 +1,25 @@
 <div [class.bg-light]="striped"
      [class.bg-white]="!striped"
      class="d-flex h-100">
-  <table-row-numbers *ngIf="isFirstPart()"
+  <table-row-numbers *ngIf="cursor | isFirstPart"
                      [table]="table"
                      [cursor]="cursor"
                      [row]="row"
                      class="table-border-right bg-white">
   </table-row-numbers>
 
-  <table-cell-group *ngIf="!isFirstPart()"
+  <table-cell-group *ngIf="!(cursor | isFirstPart)"
                     [table]="table"
                     [cursor]="cursor"
                     [row]="row">
   </table-cell-group>
 
   <table-cell-group [table]="table"
-                    [cursor]="collectionPartCursor()"
+                    [cursor]="cursor | nextPartCursor:(cursor | isFirstPart)"
                     [row]="row">
   </table-cell-group>
 
-  <div *ngIf="!isLastPart()"
+  <div *ngIf="!(cursor | isLastPart: table)"
        class="d-flex">
     <table-link-cell [cursor]="cursor"
                      [row]="row"
@@ -29,14 +29,14 @@
     <div class="d-flex flex-column">
       <table-row *ngFor="let linkedRow of row.linkedRows; trackBy: trackByLinkInstanceId; index as rowIndex"
                  [table]="table"
-                 [cursor]="createNextPartCursor(rowIndex)"
+                 [cursor]="cursor | nextPartCursor | nextRowCursor:rowIndex"
                  [row]="linkedRow"
                  class="h-100">
       </table-row>
       <table-row *ngIf="!row.linkedRows || row.linkedRows.length === 0"
                  [table]="table"
-                 [cursor]="createNextPartCursor(0)"
-                 [row]="createEmptyLinkedRow()"
+                 [cursor]="cursor | nextPartCursor | nextRowCursor:0"
+                 [row]="emptyTableRow"
                  class="h-100">
       </table-row>
     </div>

--- a/src/app/view/perspectives/table2/body/rows/row/table-row.component.ts
+++ b/src/app/view/perspectives/table2/body/rows/row/table-row.component.ts
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {Component, Input, OnChanges, OnDestroy, SimpleChanges} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, OnChanges, OnDestroy, SimpleChanges} from '@angular/core';
 import {SimpleChange} from '@angular/core/src/change_detection/change_detection_util';
 import {Store} from '@ngrx/store';
 import {filter} from 'rxjs/operators';
@@ -33,7 +33,8 @@ import {TablesAction} from '../../../../../../core/store/tables/tables.action';
 
 @Component({
   selector: 'table-row',
-  templateUrl: './table-row.component.html'
+  templateUrl: './table-row.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class TableRowComponent implements OnChanges, OnDestroy {
 
@@ -45,6 +46,8 @@ export class TableRowComponent implements OnChanges, OnDestroy {
 
   @Input()
   public row: TableRow;
+
+  public emptyTableRow = EMPTY_TABLE_ROW;
 
   public striped: boolean;
 
@@ -137,29 +140,8 @@ export class TableRowComponent implements OnChanges, OnDestroy {
     }
   }
 
-  public createNextPartCursor(rowIndex: number): TableBodyCursor {
-    return {
-      ...this.cursor,
-      partIndex: this.collectionPartCursor().partIndex + 1,
-      rowPath: [...this.cursor.rowPath, rowIndex]
-    };
-  }
-
-  public createEmptyLinkedRow(): TableRow {
-    return EMPTY_TABLE_ROW;
-  }
-
-  public collectionPartCursor(): TableBodyCursor {
-    const offset = this.isFirstPart() ? 0 : 1;
-    return {...this.cursor, partIndex: this.cursor.partIndex + offset};
-  }
-
   public isFirstPart(): boolean {
     return this.cursor.partIndex === 0;
-  }
-
-  public isLastPart(): boolean {
-    return this.cursor.partIndex + 2 > this.table.parts.length - 1;
   }
 
   public trackByLinkInstanceId(index: number, linkedRow: TableRow): string | object {

--- a/src/app/view/perspectives/table2/body/rows/table-rows.component.html
+++ b/src/app/view/perspectives/table2/body/rows/table-rows.component.html
@@ -1,12 +1,7 @@
-<div infiniteScroll
-     [infiniteScrollDistance]="2"
-     [infiniteScrollThrottle]="50"
-     (scrolled)="onScroll()"
-     [scrollWindow]="false"
-     class="d-flex flex-column">
+<div class="d-flex flex-column">
   <table-row *ngFor="let row of table.rows; trackBy: trackByDocumentId; index as rowIndex;"
              [table]="table"
-             [cursor]="createCursor(rowIndex)"
+             [cursor]="cursor | nextRowCursor:rowIndex"
              [row]="row">
   </table-row>
 </div>

--- a/src/app/view/perspectives/table2/body/table-body.component.ts
+++ b/src/app/view/perspectives/table2/body/table-body.component.ts
@@ -17,29 +17,22 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {Component, Input, OnInit} from '@angular/core';
-import {Store} from '@ngrx/store';
-import {AppState} from '../../../../core/store/app.state';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {QueryModel} from '../../../../core/store/navigation/query.model';
 import {TableModel} from '../../../../core/store/tables/table.model';
 
 @Component({
   selector: 'table-body',
   templateUrl: './table-body.component.html',
-  styleUrls: ['./table-body.component.scss']
+  styleUrls: ['./table-body.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class TableBodyComponent implements OnInit {
+export class TableBodyComponent {
 
   @Input()
   public table: TableModel;
 
   @Input()
   public query: QueryModel;
-
-  public constructor(private store: Store<AppState>) {
-  }
-
-  public ngOnInit() {
-  }
 
 }

--- a/src/app/view/perspectives/table2/header/collection/table-header-collection.component.html
+++ b/src/app/view/perspectives/table2/header/collection/table-header-collection.component.html
@@ -1,11 +1,11 @@
 <div class="d-flex flex-column align-items-start">
   <table-caption [collection]="collection$ | async"
-                 [style.width]="captionWidth()">
+                 [style.width]="part | partWidth | pixel">
   </table-caption>
   <table-column-group [table]="table"
-                      [cursor]="getCursor()"
+                      [cursor]="cursor"
                       [columns]="part.columns"
-                      [class.table-border-left]="part.index === 0"
+                      [class.table-border-left]="cursor | isFirstPart"
                       class="d-block table-border-top">
   </table-column-group>
 </div>

--- a/src/app/view/perspectives/table2/header/collection/table-header-collection.component.ts
+++ b/src/app/view/perspectives/table2/header/collection/table-header-collection.component.ts
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {Component, Input, OnChanges, SimpleChanges} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, OnChanges, SimpleChanges} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {Observable} from 'rxjs/Observable';
 import {AppState} from '../../../../../core/store/app.state';
@@ -25,20 +25,23 @@ import {CollectionModel} from '../../../../../core/store/collections/collection.
 import {selectCollectionById} from '../../../../../core/store/collections/collections.state';
 import {TableHeaderCursor} from '../../../../../core/store/tables/table-cursor';
 import {TableModel, TablePart} from '../../../../../core/store/tables/table.model';
-import {calculateColumnsWidth, filterLeafColumns} from '../../../../../core/store/tables/table.utils';
 
 @Component({
   selector: 'table-header-collection',
   templateUrl: './table-header-collection.component.html',
-  styleUrls: ['./table-header-collection.component.scss']
+  styleUrls: ['./table-header-collection.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class TableHeaderCollectionComponent implements OnChanges {
 
   @Input()
-  public table: TableModel;
+  public cursor: TableHeaderCursor;
 
   @Input()
   public part: TablePart;
+
+  @Input()
+  public table: TableModel;
 
   public collection$: Observable<CollectionModel>;
 
@@ -46,22 +49,9 @@ export class TableHeaderCollectionComponent implements OnChanges {
   }
 
   public ngOnChanges(changes: SimpleChanges): void {
-    if (changes.hasOwnProperty('part') && this.part) {
+    if (changes.part && this.part) {
       this.collection$ = this.store.select(selectCollectionById(this.part.collectionId));
     }
-  }
-
-  public getCursor(): TableHeaderCursor {
-    return {
-      tableId: this.table.id,
-      partIndex: this.part.index,
-      columnPath: []
-    };
-  }
-
-  public captionWidth(): string {
-    const width = calculateColumnsWidth(filterLeafColumns(this.part.columns));
-    return `${width}px`;
   }
 
 }

--- a/src/app/view/perspectives/table2/header/column-group/compound-column/table-compound-column.component.html
+++ b/src/app/view/perspectives/table2/header/column-group/compound-column/table-compound-column.component.html
@@ -1,9 +1,9 @@
 <div mwlResizable
      [enableGhostResize]="true"
      [ghostElementPositioning]="'absolute'"
-     [resizeEdges]="resizeEdges()"
+     [resizeEdges]="column | resizeEdges:table:cursor"
      [resizeSnapGrid]="{left: 10, right: 10}"
-     [style.width]="width()"
+     [style.width]="column | columnWidth | pixel"
      [validateResize]="validateResize.bind(this)"
      (resizeEnd)="onResizeEnd($event)">
   <div class="d-flex flex-column">
@@ -11,7 +11,7 @@
                          [cursor]="cursor"
                          [column]="column.parent"
                          [leaf]="!column.children.length"
-                         [style.height]="height()"
+                         [style.height]="column | columnHeight:table:cursor | pixel"
                          class="d-block">
     </table-single-column>
     <table-column-group *ngIf="column.children.length"

--- a/src/app/view/perspectives/table2/header/column-group/compound-column/table-compound-column.component.ts
+++ b/src/app/view/perspectives/table2/header/column-group/compound-column/table-compound-column.component.ts
@@ -23,10 +23,9 @@ import {Edges, ResizeEvent} from 'angular-resizable-element';
 import {AppState} from '../../../../../../core/store/app.state';
 import {TableHeaderCursor} from '../../../../../../core/store/tables/table-cursor';
 import {TableCompoundColumn, TableModel, TablePart} from '../../../../../../core/store/tables/table.model';
-import {calculateColumnRowspan, getTableColumnWidth, hasLastTableColumnChildHidden, hasTableColumnChildren, isLastTableColumnChild} from '../../../../../../core/store/tables/table.utils';
+import {getTableColumnWidth, hasLastTableColumnChildHidden, hasTableColumnChildren, isLastTableColumnChild} from '../../../../../../core/store/tables/table.utils';
 import {TablesAction} from '../../../../../../core/store/tables/tables.action';
 import {getLastFromArray} from '../../../../../../shared/utils/array.utils';
-import {TABLE_ROW_HEIGHT} from '../table-column-group.component';
 
 const MIN_COLUMN_WIDTH = 20;
 
@@ -50,21 +49,6 @@ export class TableCompoundColumnComponent {
   public constructor(private store: Store<AppState>) {
   }
 
-  public height(): string {
-    if (this.column.children.length) {
-      return `${TABLE_ROW_HEIGHT}px`;
-    }
-
-    const rowspan = calculateColumnRowspan(this.table, this.cursor.partIndex, this.cursor.columnPath.slice(0, this.cursor.columnPath.length - 1));
-    const height = rowspan * TABLE_ROW_HEIGHT;
-    return `${height}px`;
-  }
-
-  public width(): string {
-    const width = getTableColumnWidth(this.column);
-    return `${width}px`;
-  }
-
   public onResizeEnd(event: ResizeEvent): void {
     const delta = Number(event.edges.right);
     this.resizeColumn(delta);
@@ -83,17 +67,6 @@ export class TableCompoundColumnComponent {
     const lastChildWidth = getTableColumnWidth(lastChild);
     const delta = Number(event.edges.right);
     return lastChildWidth + delta >= MIN_COLUMN_WIDTH;
-  }
-
-  public resizeEdges(): Edges {
-    const isLastChild = isLastTableColumnChild(this.getPart().columns, this.cursor.columnPath);
-    const hasLastChildHidden = hasLastTableColumnChildHidden(this.column);
-
-    return isLastChild || hasLastChildHidden ? {} : {right: true};
-  }
-
-  private getPart(): TablePart {
-    return this.table.parts[this.cursor.partIndex];
   }
 
 }

--- a/src/app/view/perspectives/table2/header/column-group/hidden-column/table-hidden-column.component.html
+++ b/src/app/view/perspectives/table2/header/column-group/hidden-column/table-hidden-column.component.html
@@ -1,5 +1,5 @@
-<div [style.backgroundColor]="backgroundColor() | async"
-     [style.width]="width()"
+<div [style.background]="collection$ | async | columnBackground"
+     [style.width]="column | columnWidth | pixel"
      (mousedown)="onMouseDown()"
      title="Hidden columns" i18n-title="@@table.header.hidden.columns"
      class="table-border-right table-border-bottom h-100 dropdown">
@@ -9,10 +9,10 @@
     <h6 class="dropdown-header"
         i18n="@@table.header.show.hidden.columns">Show hidden columns
     </h6>
-    <a *ngFor="let attribute of hiddenAttributes() | async"
+    <a *ngFor="let attribute of hiddenAttributes$ | async"
        (click)="onShowSingleColumn(attribute)"
        class="dropdown-item">
-      <span>{{extractAttributeLastName(attribute.name)}}</span>
+      <span>{{attribute | attributeLastName}}</span>
       <small class="text-secondary pl-1">({{attribute.name}})</small>
     </a>
     <a *ngIf="column.attributeIds.length > 1"

--- a/src/app/view/perspectives/table2/header/column-group/single-column/attribute-suggestions/table-attribute-suggestions.component.html
+++ b/src/app/view/perspectives/table2/header/column-group/single-column/attribute-suggestions/table-attribute-suggestions.component.html
@@ -1,6 +1,6 @@
 <div class="dropdown">
   <div class="dropdown-menu show">
-    <ng-container *ngIf="attributeNotExists()">
+    <ng-container *ngIf="!(collection | attributeExist:attributeName)">
       <div class="dropdown-header"
            i18n="@@table.header.suggestion.attribute.new">Create new attribute
       </div>
@@ -12,15 +12,15 @@
       </a>
     </ng-container>
 
-    <ng-container *ngIf="attributeNotExists() && arePartsSuggested()">
+    <ng-container *ngIf="!(collection | attributeExist:attributeName) && (cursor | isLastPart:table) && !(table | embedded)">
       <div class="dropdown-divider"></div>
     </ng-container>
 
-    <ng-container *ngIf="arePartsSuggested()">
+    <ng-container *ngIf="(cursor | isLastPart:table) && !(table | embedded)">
       <div class="dropdown-header"
            i18n="@@table.header.suggestion.link.existing">Use existing link
       </div>
-      <a *ngFor="let linkedAttribute of suggestLinkedAttributes() | async"
+      <a *ngFor="let linkedAttribute of linkedAttributes$ | async"
          (mousedown)="useLinkType(linkedAttribute)"
          class="dropdown-item">
         <icons-presenter [colors]="[linkedAttribute.collection.color]"
@@ -34,7 +34,7 @@
       <div class="dropdown-header"
            i18n="@@table.header.suggestion.link.new">Create new link
       </div>
-      <a *ngFor="let linkedAttribute of suggestAllAttributes() | async"
+      <a *ngFor="let linkedAttribute of allAttributes$ | async"
          (mousedown)="createLinkType(linkedAttribute)"
          class="dropdown-item">
         <icons-presenter [colors]="[linkedAttribute.collection.color]"

--- a/src/app/view/perspectives/table2/header/column-group/single-column/table-single-column.component.html
+++ b/src/app/view/perspectives/table2/header/column-group/single-column/table-single-column.component.html
@@ -1,19 +1,17 @@
-<div (keydown)="onKeyDown($event)"
-     (mousedown)="onMouseDown()"
+<div (mousedown)="onMouseDown()"
      class="table-border-right table-border-bottom h-100">
   <table-editable-cell *ngIf="attribute"
-                       [contextMenu]="contextMenuElement()"
-                       [readonly]="!selected"
-                       [selected]="selected"
-                       [style.background]="background()"
-                       [value]="originalLastName()"
+                       [contextMenu]="contextMenuComponent?.contextMenu"
+                       [selected]="selected$ | async"
+                       [style.background]="collection | columnBackground:(attribute | attributeNameChanged:lastName)"
+                       [value]="attribute | attributeLastName"
                        (valueChange)="onValueChange($event)"
                        (editStart)="onEditStart()"
                        (editEnd)="onEditEnd($event)"
-                       class="d-block h-100 font-italic {{dragClass()}}">
+                       class="d-block h-100 font-italic {{cursor | dragClass}}">
   </table-editable-cell>
-  <table-attribute-suggestions *ngIf="canShowSuggestions()"
-                               [attributeName]="suggestedAttributeName()"
+  <table-attribute-suggestions *ngIf="edited && attribute && !attribute.id && !(attribute | attributeParentName)"
+                               [attributeName]="attribute | attributeName:lastName"
                                [collection]="collection"
                                [cursor]="cursor"
                                [table]="table">

--- a/src/app/view/perspectives/table2/header/column-group/table-column-group.component.html
+++ b/src/app/view/perspectives/table2/header/column-group/table-column-group.component.html
@@ -1,20 +1,19 @@
-<div [style.height]="height()">
-  <div class="muuri {{layoutContainerClass()}} h-100">
-    <div *ngFor="let column of columns; trackBy: trackByColumnAttribute; index as columnIndex"
-         [style.z-index]="zIndex(columnIndex)"
+<div [style.height]="table | headerHeight:cursor | pixel">
+  <div class="muuri {{columnGroupId | prefix:containerClassPrefix}} h-100">
+    <div *ngFor="let column of columns; trackBy: trackByCollectionAndAttribute.bind(this); index as columnIndex"
          class="muuri-item h-100">
       <div class="muuri-item-content h-100">
-        <table-compound-column *ngIf="isCompoundColumn(column)"
+        <table-compound-column *ngIf="column | isCompoundColumn"
                                [table]="table"
                                [column]="column"
-                               [cursor]="getChildCursor(columnIndex)"
+                               [cursor]="cursor | columnChildCursor:columnIndex"
                                class="d-block">
         </table-compound-column>
 
-        <table-hidden-column *ngIf="isHiddenColumn(column)"
+        <table-hidden-column *ngIf="column | isHiddenColumn"
                              [table]="table"
                              [column]="column"
-                             [cursor]="getChildCursor(columnIndex)"
+                             [cursor]="cursor | columnChildCursor:columnIndex"
                              class="d-block h-100">
         </table-hidden-column>
       </div>

--- a/src/app/view/perspectives/table2/header/link/info/table-link-info.component.html
+++ b/src/app/view/perspectives/table2/header/link/info/table-link-info.component.html
@@ -1,8 +1,8 @@
 <div class="dropdown h-100">
   <a class="d-block h-100"
      data-toggle="dropdown">
-    <icons-presenter [colors]="colors()"
-                     [icons]="icons()"
+    <icons-presenter [colors]="collections | colors"
+                     [icons]="collections | icons"
                      [title]="linkType.name">
     </icons-presenter>
   </a>

--- a/src/app/view/perspectives/table2/header/link/info/table-link-info.component.ts
+++ b/src/app/view/perspectives/table2/header/link/info/table-link-info.component.ts
@@ -18,6 +18,7 @@
  */
 
 import {ChangeDetectionStrategy, Component, EventEmitter, Input, Output} from '@angular/core';
+import {CollectionModel} from '../../../../../../core/store/collections/collection.model';
 import {LinkTypeModel} from '../../../../../../core/store/link-types/link-type.model';
 
 @Component({
@@ -27,6 +28,9 @@ import {LinkTypeModel} from '../../../../../../core/store/link-types/link-type.m
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class TableLinkInfoComponent {
+
+  @Input()
+  public collections: CollectionModel[];
 
   @Input()
   public linkType: LinkTypeModel;
@@ -39,13 +43,5 @@ export class TableLinkInfoComponent {
 
   @Output()
   public removePart = new EventEmitter();
-
-  public colors(): string[] {
-    return this.linkType.collections.map(collection => collection.color);
-  }
-
-  public icons(): string[] {
-    return this.linkType.collections.map(collection => collection.icon);
-  }
 
 }

--- a/src/app/view/perspectives/table2/header/link/table-header-link.component.html
+++ b/src/app/view/perspectives/table2/header/link/table-header-link.component.html
@@ -1,8 +1,9 @@
 <div class="d-flex flex-column h-100">
   <div class="text-white">&zwnj;</div>
   <div class="d-flex table-border-top flex-grow-2 align-items-stretch">
-    <table-link-info [linkType]="linkType"
-                     [switchingEnabled]="switchingEnabled()"
+    <table-link-info [linkType]="linkType$ | async"
+                     [collections]="collections$ | async"
+                     [switchingEnabled]="table | maxParts:3"
                      (switchParts)="onSwitchParts()"
                      (removePart)="onRemovePart()"
                      class="d-block p-1 table-border-right table-border-bottom">

--- a/src/app/view/perspectives/table2/header/table-header.component.html
+++ b/src/app/view/perspectives/table2/header/table-header.component.html
@@ -1,12 +1,14 @@
 <div class="d-flex">
-  <div [style.min-width]="rowNumberWidth()"
-       [style.width]="rowNumberWidth()"></div>
+  <div [style.min-width]="table | rowNumberWidth"
+       [style.width]="table | rowNumberWidth"></div>
   <ng-container *ngFor="let part of table.parts; trackBy: trackByPartIndex">
     <table-header-collection *ngIf="part.collectionId"
+                             [cursor]="cursor | partCursor:part.index"
                              [table]="table"
                              [part]="part">
     </table-header-collection>
     <table-header-link *ngIf="part.linkTypeId"
+                       [cursor]="cursor | partCursor:part.index"
                        [table]="table"
                        [part]="part">
     </table-header-link>

--- a/src/app/view/perspectives/table2/header/table-header.component.ts
+++ b/src/app/view/perspectives/table2/header/table-header.component.ts
@@ -17,7 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, SimpleChange, SimpleChanges} from '@angular/core';
+import {TableHeaderCursor} from '../../../../core/store/tables/table-cursor';
 import {TableModel, TablePart} from '../../../../core/store/tables/table.model';
 
 @Component({
@@ -31,12 +32,28 @@ export class TableHeaderComponent {
   @Input()
   public table: TableModel;
 
+  public cursor: TableHeaderCursor;
+
+  public ngOnChanges(changes: SimpleChanges): void {
+    if (changes.table && this.table && hasTableIdChanged(changes.table)) {
+      this.cursor = this.createHeaderRootCursor();
+    }
+  }
+
+  private createHeaderRootCursor(): TableHeaderCursor {
+    return {
+      tableId: this.table.id,
+      partIndex: null,
+      columnPath: []
+    };
+  }
+
   public trackByPartIndex(index: number, part: TablePart): number {
     return part.index;
   }
 
-  public rowNumberWidth(): string {
-    return `${this.table.rowNumberWidth}px`;
-  }
+}
 
+function hasTableIdChanged(change: SimpleChange): boolean {
+  return !change.previousValue || change.previousValue.id !== change.currentValue.id;
 }

--- a/src/app/view/perspectives/table2/shared/editable-cell/table-editable-cell.component.html
+++ b/src/app/view/perspectives/table2/shared/editable-cell/table-editable-cell.component.html
@@ -1,5 +1,6 @@
 <div #editableCell
      [attr.spellcheck]="false"
+     [attr.tabindex]="selected ? 1 : null"
      [attr.contenteditable]="edited"
      [class.affected]="affected && !selected"
      [class.selected]="selected"
@@ -11,6 +12,5 @@
      (dblclick)="onDoubleClick()"
      (keydown)="onKeyDown($event)"
      (input)="onInput($event)"
-     class="editable-cell h-100 p-1 text-nowrap overflow-hidden"
-     tabindex="0">
+     class="editable-cell h-100 p-1 text-nowrap overflow-hidden">
 </div>

--- a/src/app/view/perspectives/table2/shared/pipes/attribute-exist.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/attribute-exist.pipe.ts
@@ -1,0 +1,17 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import {CollectionModel} from '../../../../../core/store/collections/collection.model';
+import {findAttributeByName} from '../../../../../shared/utils/attribute.utils';
+
+@Pipe({
+  name: 'attributeExist'
+})
+export class AttributeExistPipe implements PipeTransform {
+
+  public transform(collection: CollectionModel, attributeName: string): boolean {
+    if (collection) {
+      return !!findAttributeByName(collection.attributes, attributeName);
+    }
+    return false;
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/attribute-last-name.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/attribute-last-name.pipe.ts
@@ -1,0 +1,14 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {AttributeModel} from '../../../../../core/store/collections/collection.model';
+import {extractAttributeLastName} from '../../../../../shared/utils/attribute.utils';
+
+@Pipe({
+  name: 'attributeLastName'
+})
+export class AttributeLastNamePipe implements PipeTransform {
+
+  public transform(attribute: AttributeModel): string {
+    return extractAttributeLastName(attribute.name);
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/attribute-name-changed.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/attribute-name-changed.pipe.ts
@@ -1,0 +1,14 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import {AttributeModel} from '../../../../../core/store/collections/collection.model';
+import {extractAttributeLastName} from '../../../../../shared/utils/attribute.utils';
+
+@Pipe({
+  name: 'attributeNameChanged'
+})
+export class AttributeNameChangedPipe implements PipeTransform {
+
+  public transform(attribute: AttributeModel, newLastName: string): boolean {
+    return !attribute || !attribute.id || extractAttributeLastName(attribute.name) !== newLastName;
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/attribute-name.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/attribute-name.pipe.ts
@@ -1,0 +1,23 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {AttributeModel} from '../../../../../core/store/collections/collection.model';
+import {extractAttributeParentName} from '../../../../../shared/utils/attribute.utils';
+
+@Pipe({
+  name: 'attributeName'
+})
+export class AttributeNamePipe implements PipeTransform {
+
+  public transform(attribute: AttributeModel, newLastName: string): any {
+    if (!attribute) {
+      return '';
+    }
+
+    const parentName = extractAttributeParentName(attribute.name);
+    if (parentName) {
+      return `${parentName}.${newLastName}`;
+    }
+
+    return newLastName;
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/attribute-parent-name.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/attribute-parent-name.pipe.ts
@@ -1,0 +1,14 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {AttributeModel} from '../../../../../core/store/collections/collection.model';
+import {extractAttributeParentName} from '../../../../../shared/utils/attribute.utils';
+
+@Pipe({
+  name: 'attributeParentName'
+})
+export class AttributeParentNamePipe implements PipeTransform {
+
+  public transform(attribute: AttributeModel): string {
+    return extractAttributeParentName(attribute.name);
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/collapsible.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/collapsible.pipe.ts
@@ -1,0 +1,13 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {TableRow} from '../../../../../core/store/tables/table.model';
+
+@Pipe({
+  name: 'collapsible'
+})
+export class CollapsiblePipe implements PipeTransform {
+
+  public transform(row: TableRow): boolean {
+    return row.linkedRows && row.linkedRows.length > 1;
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/column-background.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/column-background.pipe.ts
@@ -1,0 +1,24 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {CollectionModel} from '../../../../../core/store/collections/collection.model';
+import {HtmlModifier, stripedBackground} from '../../../../../shared/utils/html-modifier';
+
+export const DEFAULT_COLOR = '#ffffff';
+export const DEFAULT_STRIPED_COLOR = '#eeeeee';
+
+@Pipe({
+  name: 'columnBackground'
+})
+export class ColumnBackgroundPipe implements PipeTransform {
+
+  public transform(collection: CollectionModel, unsaved?: boolean): any {
+    const color = collection ? HtmlModifier.shadeColor(collection.color, .5) : DEFAULT_COLOR;
+    const stripeColor = collection ? HtmlModifier.shadeColor(color, .25) : DEFAULT_STRIPED_COLOR;
+
+    if (unsaved) {
+      return stripedBackground(color, stripeColor);
+    }
+
+    return color;
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/column-child-cursor.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/column-child-cursor.pipe.ts
@@ -1,0 +1,13 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {TableHeaderCursor} from '../../../../../core/store/tables/table-cursor';
+
+@Pipe({
+  name: 'columnChildCursor'
+})
+export class ColumnChildCursorPipe implements PipeTransform {
+
+  public transform(cursor: TableHeaderCursor, columnIndex: number): TableHeaderCursor {
+    return {...cursor, columnPath: cursor.columnPath.concat(columnIndex)};
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/column-cursor.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/column-cursor.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import {TableBodyCursor} from '../../../../../core/store/tables/table-cursor';
+
+@Pipe({
+  name: 'columnCursor'
+})
+export class ColumnCursorPipe implements PipeTransform {
+
+  public transform(cursor: TableBodyCursor, columnIndex: number): TableBodyCursor {
+    return {...cursor, columnIndex};
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/column-height.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/column-height.pipe.ts
@@ -1,0 +1,22 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {TableHeaderCursor} from '../../../../../core/store/tables/table-cursor';
+import {TableCompoundColumn, TableModel} from '../../../../../core/store/tables/table.model';
+import {calculateColumnRowspan} from '../../../../../core/store/tables/table.utils';
+
+export const TABLE_ROW_HEIGHT = 35;
+
+@Pipe({
+  name: 'columnHeight'
+})
+export class ColumnHeightPipe implements PipeTransform {
+
+  public transform(column: TableCompoundColumn, table: TableModel, cursor: TableHeaderCursor): number {
+    if (column.children.length) {
+      return TABLE_ROW_HEIGHT;
+    }
+
+    const rowspan = calculateColumnRowspan(table, cursor.partIndex, cursor.columnPath.slice(0, cursor.columnPath.length - 1));
+    return rowspan * TABLE_ROW_HEIGHT;
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/column-width.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/column-width.pipe.ts
@@ -1,0 +1,14 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import {TableColumn} from '../../../../../core/store/tables/table.model';
+import {getTableColumnWidth} from '../../../../../core/store/tables/table.utils';
+
+@Pipe({
+  name: 'columnWidth'
+})
+export class ColumnWidthPipe implements PipeTransform {
+
+  public transform(column: TableColumn): number {
+    return getTableColumnWidth(column);
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/data.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/data.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'data'
+})
+export class DataPipe implements PipeTransform {
+
+  public transform(entity: {data: any}, attributeId: string): any {
+    return entity && entity.data ? entity.data[attributeId] || '' : '';
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/displayable.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/displayable.pipe.ts
@@ -1,0 +1,13 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {QueryModel} from '../../../../../core/store/navigation/query.model';
+
+@Pipe({
+  name: 'displayable'
+})
+export class DisplayablePipe implements PipeTransform {
+
+  public transform(query: QueryModel): boolean {
+    return query && query.collectionIds && query.collectionIds.length === 1;
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/drag-class.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/drag-class.pipe.ts
@@ -1,0 +1,14 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {TableHeaderCursor} from '../../../../../core/store/tables/table-cursor';
+
+@Pipe({
+  name: 'dragClass'
+})
+export class DragClassPipe implements PipeTransform {
+
+  public transform(cursor: TableHeaderCursor): any {
+    const path = cursor.columnPath.slice(0, -1);
+    return `drag-${cursor.tableId}-${cursor.partIndex}-${path.join('-')}`;
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/embedded.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/embedded.pipe.ts
@@ -1,0 +1,13 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {DEFAULT_TABLE_ID, TableModel} from '../../../../../core/store/tables/table.model';
+
+@Pipe({
+  name: 'embedded'
+})
+export class EmbeddedPipe implements PipeTransform {
+
+  public transform(table: TableModel): boolean {
+    return table && table.id !== DEFAULT_TABLE_ID;
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/entity-created.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/entity-created.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'entityCreated'
+})
+export class EntityCreatedPipe implements PipeTransform {
+
+  public transform(entity: {id: any}): boolean {
+    return entity && entity.id;
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/expandable.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/expandable.pipe.ts
@@ -1,0 +1,18 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {TableRow} from '../../../../../core/store/tables/table.model';
+
+@Pipe({
+  name: 'expandable'
+})
+export class ExpandablePipe implements PipeTransform {
+
+  public transform(row: TableRow): boolean {
+    if (!row.linkedRows || row.linkedRows.length !== 1) {
+      return false;
+    }
+    const linkedRow = row.linkedRows[0];
+    return (linkedRow.documentIds && linkedRow.documentIds.length > 1) ||
+      (linkedRow.linkInstanceIds && linkedRow.linkInstanceIds.length > 1);
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/header-height.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/header-height.pipe.ts
@@ -1,0 +1,17 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {TableHeaderCursor} from '../../../../../core/store/tables/table-cursor';
+import {TableModel} from '../../../../../core/store/tables/table.model';
+import {calculateColumnRowspan} from '../../../../../core/store/tables/table.utils';
+import {TABLE_ROW_HEIGHT} from './column-height.pipe';
+
+@Pipe({
+  name: 'headerHeight'
+})
+export class HeaderHeightPipe implements PipeTransform {
+
+  public transform(table: TableModel, cursor: TableHeaderCursor): number {
+    const rowspan = calculateColumnRowspan(table, cursor.partIndex, cursor.columnPath);
+    return rowspan * TABLE_ROW_HEIGHT;
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/is-compound-column.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/is-compound-column.pipe.ts
@@ -1,0 +1,13 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {TableColumn, TableColumnType} from '../../../../../core/store/tables/table.model';
+
+@Pipe({
+  name: 'isCompoundColumn'
+})
+export class IsCompoundColumnPipe implements PipeTransform {
+
+  public transform(column: TableColumn): boolean {
+    return column.type === TableColumnType.COMPOUND;
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/is-first-part.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/is-first-part.pipe.ts
@@ -1,0 +1,13 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {TableCursor} from '../../../../../core/store/tables/table-cursor';
+
+@Pipe({
+  name: 'isFirstPart'
+})
+export class IsFirstPartPipe implements PipeTransform {
+
+  public transform(cursor: TableCursor): boolean {
+    return cursor && cursor.partIndex === 0;
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/is-hidden-column.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/is-hidden-column.pipe.ts
@@ -1,0 +1,13 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {TableColumn, TableColumnType} from '../../../../../core/store/tables/table.model';
+
+@Pipe({
+  name: 'isHiddenColumn'
+})
+export class IsHiddenColumnPipe implements PipeTransform {
+
+  public transform(column: TableColumn): boolean {
+    return column.type === TableColumnType.HIDDEN;
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/is-last-part.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/is-last-part.pipe.ts
@@ -1,0 +1,14 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import {TableCursor} from '../../../../../core/store/tables/table-cursor';
+import {TableModel} from '../../../../../core/store/tables/table.model';
+
+@Pipe({
+  name: 'isLastPart'
+})
+export class IsLastPartPipe implements PipeTransform {
+
+  public transform(cursor: TableCursor, table: TableModel): boolean {
+    return cursor && table && cursor.partIndex + 2 > table.parts.length - 1;
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/is-single-column.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/is-single-column.pipe.ts
@@ -1,0 +1,13 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {TableColumn, TableColumnType} from '../../../../../core/store/tables/table.model';
+
+@Pipe({
+  name: 'isSingleColumn'
+})
+export class IsSingleColumnPipe implements PipeTransform {
+
+  public transform(column: TableColumn): boolean {
+    return column.type === TableColumnType.SINGLE;
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/max-parts.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/max-parts.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import {TableModel} from '../../../../../core/store/tables/table.model';
+
+@Pipe({
+  name: 'maxParts'
+})
+export class MaxPartsPipe implements PipeTransform {
+
+  public transform(table: TableModel, maxNumber: number): boolean {
+    return table.parts.length <= maxNumber;
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/next-part-cursor.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/next-part-cursor.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import {TableCursor} from '../../../../../core/store/tables/table-cursor';
+
+@Pipe({
+  name: 'nextPartCursor'
+})
+export class NextPartCursorPipe implements PipeTransform {
+
+  public transform(cursor: TableCursor, skip?: boolean): TableCursor {
+    return {...cursor, partIndex: cursor.partIndex + (skip ? 0 : 1)};
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/next-row-cursor.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/next-row-cursor.pipe.ts
@@ -1,0 +1,13 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {TableBodyCursor} from '../../../../../core/store/tables/table-cursor';
+
+@Pipe({
+  name: 'nextRowCursor'
+})
+export class NextRowCursorPipe implements PipeTransform {
+
+  public transform(cursor: TableBodyCursor, rowIndex: number): TableBodyCursor {
+    return {...cursor, rowPath: cursor.rowPath.concat(rowIndex)};
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/part-cursor.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/part-cursor.pipe.ts
@@ -1,0 +1,13 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {TableCursor} from '../../../../../core/store/tables/table-cursor';
+
+@Pipe({
+  name: 'partCursor'
+})
+export class PartCursorPipe implements PipeTransform {
+
+  public transform(cursor: TableCursor, partIndex: number): TableCursor {
+    return {...cursor, partIndex};
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/part-width.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/part-width.pipe.ts
@@ -1,0 +1,14 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {TablePart} from '../../../../../core/store/tables/table.model';
+import {calculateColumnsWidth, filterLeafColumns} from '../../../../../core/store/tables/table.utils';
+
+@Pipe({
+  name: 'partWidth'
+})
+export class PartWidthPipe implements PipeTransform {
+
+  public transform(part: TablePart): number {
+    return calculateColumnsWidth(filterLeafColumns(part.columns));
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/part.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/part.pipe.ts
@@ -1,0 +1,14 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {TableHeaderCursor} from '../../../../../core/store/tables/table-cursor';
+import {TableModel, TablePart} from '../../../../../core/store/tables/table.model';
+
+@Pipe({
+  name: 'part'
+})
+export class PartPipe implements PipeTransform {
+
+  public transform(table: TableModel, cursor: TableHeaderCursor): TablePart {
+    return table.parts[cursor.partIndex];
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/resize-edges.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/resize-edges.pipe.ts
@@ -1,0 +1,19 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import {Edges} from 'angular-resizable-element';
+import {TableHeaderCursor} from '../../../../../core/store/tables/table-cursor';
+import {TableCompoundColumn, TableModel} from '../../../../../core/store/tables/table.model';
+import {hasLastTableColumnChildHidden, isLastTableColumnChild} from '../../../../../core/store/tables/table.utils';
+
+@Pipe({
+  name: 'resizeEdges'
+})
+export class ResizeEdgesPipe implements PipeTransform {
+
+  public transform(column: TableCompoundColumn, table: TableModel, cursor: TableHeaderCursor): Edges {
+    const part = table.parts[cursor.partIndex];
+    const isLastChild = isLastTableColumnChild(part.columns, cursor.columnPath);
+    const hasLastChildHidden = hasLastTableColumnChildHidden(column);
+    return isLastChild || hasLastChildHidden ? {} : {right: true};
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/row-number-width.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/row-number-width.pipe.ts
@@ -1,0 +1,14 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {DEFAULT_ROW_NUMBER_WIDTH, TableModel} from '../../../../../core/store/tables/table.model';
+
+@Pipe({
+  name: 'rowNumberWidth'
+})
+export class RowNumberWidthPipe implements PipeTransform {
+
+  public transform(table: TableModel): string {
+    const rowNumberWidth = table.rowNumberWidth || DEFAULT_ROW_NUMBER_WIDTH;
+    return `${rowNumberWidth}px`;
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/table-pipes.module.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/table-pipes.module.ts
@@ -1,0 +1,128 @@
+/*
+ * Lumeer: Modern Data Definition and Processing Platform
+ *
+ * Copyright (C) since 2017 Answer Institute, s.r.o. and/or its affiliates.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {AttributeExistPipe} from './attribute-exist.pipe';
+import {AttributeLastNamePipe} from './attribute-last-name.pipe';
+import {AttributeNameChangedPipe} from './attribute-name-changed.pipe';
+import {AttributeNamePipe} from './attribute-name.pipe';
+import {AttributeParentNamePipe} from './attribute-parent-name.pipe';
+import {CollapsiblePipe} from './collapsible.pipe';
+import {ColumnBackgroundPipe} from './column-background.pipe';
+import {ColumnChildCursorPipe} from './column-child-cursor.pipe';
+import {ColumnCursorPipe} from './column-cursor.pipe';
+import {ColumnHeightPipe} from './column-height.pipe';
+import {ColumnWidthPipe} from './column-width.pipe';
+import {DataPipe} from './data.pipe';
+import {DisplayablePipe} from './displayable.pipe';
+import {DragClassPipe} from './drag-class.pipe';
+import {EmbeddedPipe} from './embedded.pipe';
+import {EntityCreatedPipe} from './entity-created.pipe';
+import {ExpandablePipe} from './expandable.pipe';
+import {HeaderHeightPipe} from './header-height.pipe';
+import {IsCompoundColumnPipe} from './is-compound-column.pipe';
+import {IsFirstPartPipe} from './is-first-part.pipe';
+import {IsHiddenColumnPipe} from './is-hidden-column.pipe';
+import {IsLastPartPipe} from './is-last-part.pipe';
+import {IsSingleColumnPipe} from './is-single-column.pipe';
+import {MaxPartsPipe} from './max-parts.pipe';
+import {NextPartCursorPipe} from './next-part-cursor.pipe';
+import {NextRowCursorPipe} from './next-row-cursor.pipe';
+import {PartCursorPipe} from './part-cursor.pipe';
+import {PartWidthPipe} from './part-width.pipe';
+import {PartPipe} from './part.pipe';
+import {ResizeEdgesPipe} from './resize-edges.pipe';
+import {RowNumberWidthPipe} from './row-number-width.pipe';
+
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  declarations: [
+    DataPipe,
+    EntityCreatedPipe,
+    IsFirstPartPipe,
+    IsLastPartPipe,
+    NextPartCursorPipe,
+    NextRowCursorPipe,
+    RowNumberWidthPipe,
+    ExpandablePipe,
+    CollapsiblePipe,
+    DisplayablePipe,
+    PartWidthPipe,
+    PartCursorPipe,
+    MaxPartsPipe,
+    ColumnChildCursorPipe,
+    HeaderHeightPipe,
+    IsCompoundColumnPipe,
+    IsHiddenColumnPipe,
+    AttributeLastNamePipe,
+    ColumnWidthPipe,
+    ColumnCursorPipe,
+    IsSingleColumnPipe,
+    ColumnHeightPipe,
+    ResizeEdgesPipe,
+    ColumnBackgroundPipe,
+    PartPipe,
+    AttributeNameChangedPipe,
+    DragClassPipe,
+    AttributeNamePipe,
+    AttributeParentNamePipe,
+    AttributeExistPipe,
+    EmbeddedPipe
+  ], exports: [
+    DataPipe,
+    EntityCreatedPipe,
+    IsFirstPartPipe,
+    IsLastPartPipe,
+    NextPartCursorPipe,
+    NextRowCursorPipe,
+    RowNumberWidthPipe,
+    ExpandablePipe,
+    CollapsiblePipe,
+    DisplayablePipe,
+    PartWidthPipe,
+    PartCursorPipe,
+    MaxPartsPipe,
+    ColumnChildCursorPipe,
+    HeaderHeightPipe,
+    IsCompoundColumnPipe,
+    IsHiddenColumnPipe,
+    AttributeLastNamePipe,
+    ColumnWidthPipe,
+    ColumnCursorPipe,
+    IsSingleColumnPipe,
+    ColumnHeightPipe,
+    ResizeEdgesPipe,
+    ColumnBackgroundPipe,
+    PartPipe,
+    AttributeNameChangedPipe,
+    DragClassPipe,
+    AttributeNamePipe,
+    AttributeParentNamePipe,
+    AttributeExistPipe,
+    EmbeddedPipe
+  ],
+  providers: [
+    AttributeNameChangedPipe
+  ]
+})
+export class TablePipesModule {
+}

--- a/src/app/view/perspectives/table2/table2-perspective.component.html
+++ b/src/app/view/perspectives/table2/table2-perspective.component.html
@@ -1,12 +1,12 @@
-<div *ngIf="!isDisplayable()"
+<div *ngIf="!(query | displayable)"
      class="alert alert-warning m-3"
      role="alert"
      i18n="@@table.query.invalid">Your query results cannot be shown using table perspective. The query needs to specify exactly one file.
 </div>
 
 <div #positioner></div>
-<div *ngIf="isDisplayable()"
-     [style.height]="height(positioner)"
+<div *ngIf="query | displayable"
+     [style.height]="height"
      (clickOutside)="onClickOutside()"
      class="table d-flex flex-column m-0">
   <table-header [table]="table">

--- a/src/app/view/perspectives/table2/table2-perspective.module.ts
+++ b/src/app/view/perspectives/table2/table2-perspective.module.ts
@@ -17,7 +17,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {EffectsModule} from '@ngrx/effects';
 import {StoreModule} from '@ngrx/store';
@@ -29,6 +28,7 @@ import {TablesEffects} from '../../../core/store/tables/tables.effects';
 import {tablesReducer} from '../../../core/store/tables/tables.reducer';
 import {initialTablesState, TABLE_FEATURE_NAME} from '../../../core/store/tables/tables.state';
 import {PickerModule} from '../../../shared/picker/picker.module';
+import {PipesModule} from '../../../shared/pipes/pipes.module';
 import {SharedModule} from '../../../shared/shared.module';
 import {TableRowGroupFooterComponent} from './body/row-group/footer/table-row-group-footer.component';
 import {TableRowGroupHeaderComponent} from './body/row-group/header/table-row-group-header.component';
@@ -56,20 +56,22 @@ import {TableLinkInfoComponent} from './header/link/info/table-link-info.compone
 import {TableHeaderLinkComponent} from './header/link/table-header-link.component';
 import {TableHeaderComponent} from './header/table-header.component';
 import {TableEditableCellComponent} from './shared/editable-cell/table-editable-cell.component';
+import {TablePipesModule} from './shared/pipes/table-pipes.module';
 import {TablePerspectiveRoutingModule} from './table-perspective-routing.module';
 import {Table2PerspectiveComponent} from './table2-perspective.component';
 
 @NgModule({
   imports: [
     SharedModule,
-    CommonModule,
     PickerModule,
+    PipesModule,
     StoreModule.forFeature(TABLE_FEATURE_NAME, tablesReducer, {initialState: initialTablesState}),
     EffectsModule.forFeature([TablesEffects]),
     ContextMenuModule,
     ClickOutsideModule,
     ResizableModule,
     InfiniteScrollModule,
+    TablePipesModule,
     TablePerspectiveRoutingModule
   ],
   declarations: [
@@ -99,7 +101,7 @@ import {Table2PerspectiveComponent} from './table2-perspective.component';
     TableDataCellMenuComponent,
     TableCollapsedCellComponent,
     TableRowNumbersComponent,
-    TableDataCellSuggestionsComponent
+    TableDataCellSuggestionsComponent,
   ],
   exports: [
     Table2PerspectiveComponent


### PR DESCRIPTION
I have tweaked table perspective components a little bit in order to get maximum performance on big tables. They now use `OnPush` change detection and pure pipes almost everywhere. The other thing that was slowing the application was using `focus()` method when changing table cursor which took a while when there are many elements in the DOM.

The table perspective is still slow on very large tables but it is due to long browser layout rendering times cased by a lot of elements in the DOM. This will be resolved in the next pull-request by implementing infinite scroll so hidden elements will not be present in the DOM.