### PR TITLE
Fix table perspective UX issues #LMR-914

### DIFF
--- a/src/app/core/store/app-store.module.ts
+++ b/src/app/core/store/app-store.module.ts
@@ -94,7 +94,7 @@ const effects = [
   imports: [
     StoreModule.forRoot(reducers, {initialState: initialAppState}),
     EffectsModule.forRoot(effects),
-    LUMEER_ENV === 'development' ? StoreDevtoolsModule.instrument({maxAge: 10}) : []
+    LUMEER_ENV === 'development' ? StoreDevtoolsModule.instrument({maxAge: 15}) : []
   ],
   declarations: []
 })

--- a/src/app/core/store/documents/documents.effects.ts
+++ b/src/app/core/store/documents/documents.effects.ts
@@ -30,7 +30,7 @@ import {AttributeModel, CollectionModel} from '../collections/collection.model';
 import {CollectionsAction} from '../collections/collections.action';
 import {selectCollectionById} from '../collections/collections.state';
 import {QueryConverter} from '../navigation/query.converter';
-import {QueryHelper} from '../navigation/query.helper';
+import {areQueriesEqual} from '../navigation/query.helper';
 import {NotificationsAction} from '../notifications/notifications.action';
 import {DocumentConverter} from './document.converter';
 import {DocumentModel} from './document.model';
@@ -47,7 +47,7 @@ export class DocumentsEffects {
   public get$: Observable<Action> = this.actions$.pipe(
     ofType<DocumentsAction.Get>(DocumentsActionType.GET),
     withLatestFrom(this.store$.select(selectDocumentsQueries)),
-    skipWhile(([action, queries]) => queries.some(query => QueryHelper.equal(query, action.payload.query))),
+    skipWhile(([action, queries]) => queries.some(query => areQueriesEqual(query, action.payload.query))),
     mergeMap(([action]) => {
       const queryDto = QueryConverter.toDto(action.payload.query);
 

--- a/src/app/core/store/link-instances/link-instances.effects.ts
+++ b/src/app/core/store/link-instances/link-instances.effects.ts
@@ -25,7 +25,7 @@ import {Observable} from 'rxjs/Observable';
 import {catchError, map, mergeMap, skipWhile, tap, withLatestFrom} from 'rxjs/operators';
 import {LinkInstanceService} from '../../rest';
 import {AppState} from '../app.state';
-import {QueryHelper} from '../navigation/query.helper';
+import {areQueriesEqual} from '../navigation/query.helper';
 import {NotificationsAction} from '../notifications/notifications.action';
 import {LinkInstanceConverter} from './link-instance.converter';
 import {LinkInstancesAction, LinkInstancesActionType} from './link-instances.action';
@@ -38,7 +38,7 @@ export class LinkInstancesEffects {
   public get$: Observable<Action> = this.actions$.pipe(
     ofType<LinkInstancesAction.Get>(LinkInstancesActionType.GET),
     withLatestFrom(this.store$.select(selectLinkInstancesQueries)),
-    skipWhile(([action, queries]) => queries.some(query => QueryHelper.equal(query, action.payload.query))),
+    skipWhile(([action, queries]) => queries.some(query => areQueriesEqual(query, action.payload.query))),
     mergeMap(([action]) => this.linkInstanceService.getLinkInstances(action.payload.query).pipe(
       map(dtos => ({action, linkInstances: dtos.map(dto => LinkInstanceConverter.fromDto(dto))})),
       map(({action, linkInstances}) => new LinkInstancesAction.GetSuccess({linkInstances: linkInstances, query: action.payload.query})),

--- a/src/app/core/store/navigation/query.helper.ts
+++ b/src/app/core/store/navigation/query.helper.ts
@@ -21,12 +21,8 @@ import {deepArrayEquals, getArrayDifference, isArraySubset} from '../../../share
 import {QueryConverter} from './query.converter';
 import {QueryModel} from './query.model';
 
-export class QueryHelper {
-
-  public static equal(first: QueryModel, second: QueryModel): boolean {
-    return QueryConverter.toString(first) === QueryConverter.toString(second);
-  }
-
+export function areQueriesEqual(first: QueryModel, second: QueryModel): boolean {
+  return QueryConverter.toString(first) === QueryConverter.toString(second);
 }
 
 export function hasQueryNewLink(oldQuery: QueryModel, newQuery: QueryModel) {

--- a/src/app/core/store/tables/table.utils.ts
+++ b/src/app/core/store/tables/table.utils.ts
@@ -21,6 +21,7 @@ import {copyAndSpliceArray, getLastFromArray} from '../../../shared/utils/array.
 import {filterDirectAttributeChildren, findAttributeByName, splitAttributeName} from '../../../shared/utils/attribute.utils';
 import {AttributeModel, CollectionModel} from '../collections/collection.model';
 import {LinkTypeModel} from '../link-types/link-type.model';
+import {TableCursor} from './table-cursor';
 import {TableColumn, TableColumnType, TableCompoundColumn, TableConfig, TableConfigColumn, TableConfigPart, TableHiddenColumn, TableModel, TablePart, TableRow, TableSingleColumn} from './table.model';
 
 export function findTableColumn(columns: TableColumn[], path: number[]): TableColumn {
@@ -393,4 +394,13 @@ export function isTableRowStriped(rowPath: number[]): boolean {
   }
 
   return isTableRowStriped(parentPath) ? rowIndex % 2 === 0 : rowIndex % 2 === 1;
+}
+
+export function isLastTableColumn(cursor: TableCursor, part: TablePart): boolean {
+  return (cursor.columnPath && cursor.columnPath.length === 1 && cursor.columnPath[0] === part.columns.length - 1) ||
+    (cursor.columnIndex && cursor.columnIndex === part.columns.length - 1);
+}
+
+export function isLastTableRow(cursor: TableCursor, table: TableModel): boolean {
+  return cursor.rowPath && cursor.rowPath.length === 1 && cursor.rowPath[0] === table.rows.length - 1;
 }

--- a/src/app/core/store/tables/tables.action.ts
+++ b/src/app/core/store/tables/tables.action.ts
@@ -69,6 +69,7 @@ export enum TablesActionType {
   MOVE_CELL = '[Tables] Move Cell',
 
   SET_CURSOR = '[Tables] Set Cursor',
+  SET_CURSOR_SUCCESS = '[Tables] Set Cursor :: Success',
   MOVE_CURSOR = '[Tables] Move Cursor',
 
   SET_EDITED_ATTRIBUTE = '[Tables] Set Edited Attribute',
@@ -144,7 +145,7 @@ export namespace TablesAction {
   export class AddColumn implements TableCursorAction {
     public readonly type = TablesActionType.ADD_COLUMN;
 
-    public constructor(public payload: { cursor: TableHeaderCursor, column: TableColumn }) {
+    public constructor(public payload: { cursor: TableHeaderCursor }) {
     }
   }
 
@@ -253,6 +254,13 @@ export namespace TablesAction {
     }
   }
 
+  export class SetCursorSuccess implements TableCursorAction {
+    public readonly type = TablesActionType.SET_CURSOR_SUCCESS;
+
+    public constructor(public payload: { cursor: TableCursor }) {
+    }
+  }
+
   export class MoveCursor implements Action {
     public readonly type = TablesActionType.MOVE_CURSOR;
 
@@ -281,6 +289,6 @@ export namespace TablesAction {
     MoveColumn | ResizeColumn | InitColumn |
     ReplaceRows | AddRows | AddLinkedRows | RemoveRow |
     CollapseRows | ExpandRows |
-    SetCursor | MoveCursor |
+    SetCursor | SetCursorSuccess | MoveCursor |
     EditSelectedCell | SetEditedAttribute;
 }

--- a/src/app/core/store/tables/tables.reducer.ts
+++ b/src/app/core/store/tables/tables.reducer.ts
@@ -102,7 +102,8 @@ function addRows(state: TablesState, action: TablesAction.AddRows): TablesState 
   }
 
   const documentIds = new Set(table.documentIds);
-  addedRows.forEach(row => documentIds.add(row.documentIds[0]));
+  addedRows.filter(row => row.documentIds.length > 0)
+    .forEach(row => documentIds.add(row.documentIds[0]));
 
   return tablesAdapter.updateOne({id: table.id, changes: {rows, documentIds}}, state);
 }

--- a/src/app/core/store/tables/tables.reducer.ts
+++ b/src/app/core/store/tables/tables.reducer.ts
@@ -18,9 +18,9 @@
  */
 
 import {copyAndSpliceArray} from '../../../shared/utils/array.utils';
-import {TableBodyCursor, TableHeaderCursor} from './table-cursor';
-import {EMPTY_TABLE_ROW, TableColumn, TableModel, TablePart, TableRow} from './table.model';
-import {addTableColumn, maxColumnDepth, moveTableColumn, replaceTableColumns, splitRowPath} from './table.utils';
+import {TableHeaderCursor} from './table-cursor';
+import {TableColumn, TableModel, TablePart, TableRow} from './table.model';
+import {maxColumnDepth, moveTableColumn, replaceTableColumns, splitRowPath} from './table.utils';
 import {TablesAction, TablesActionType} from './tables.action';
 import {initialTablesState, tablesAdapter, TablesState} from './tables.state';
 
@@ -32,8 +32,6 @@ export function tablesReducer(state = initialTablesState(), action: TablesAction
       return tablesAdapter.removeOne(action.payload.tableId, state);
     case TablesActionType.ADD_PART:
       return addPart(state, action);
-    case TablesActionType.ADD_COLUMN:
-      return addColumn(state, action);
     case TablesActionType.REPLACE_COLUMNS:
       return replaceColumn(state, action);
     case TablesActionType.MOVE_COLUMN:
@@ -46,8 +44,8 @@ export function tablesReducer(state = initialTablesState(), action: TablesAction
       return replaceRows(state, action);
     case TablesActionType.REMOVE_ROW:
       return removeRow(state, action);
-    case TablesActionType.SET_CURSOR:
-      return setCursor(state, action);
+    case TablesActionType.SET_CURSOR_SUCCESS:
+      return {...state, cursor: action.payload.cursor};
     case TablesActionType.SET_EDITED_ATTRIBUTE:
       return {...state, editedAttribute: action.payload.editedAttribute};
     default:
@@ -59,12 +57,6 @@ function addPart(state: TablesState, action: TablesAction.AddPart): TablesState 
   const table = state.entities[action.payload.tableId];
   const parts = table.parts.concat(action.payload.parts);
   return tablesAdapter.updateOne({id: table.id, changes: {parts}}, state);
-}
-
-function addColumn(state: TablesState, action: TablesAction.AddColumn): TablesState {
-  return updateColumns(state, action.payload.cursor, (columns) => {
-    return addTableColumn(columns, action.payload.cursor.columnPath, action.payload.column);
-  });
 }
 
 function replaceColumn(state: TablesState, action: TablesAction.ReplaceColumns): TablesState {
@@ -190,25 +182,6 @@ function removeLinkedRow(rows: TableRow[], rowPath: number[]): TableRow[] {
   row.linkedRows = removeLinkedRow(row.linkedRows, rowPath.slice(1));
   updatedRows.splice(rowIndex, 1, row);
   return updatedRows;
-}
-
-export function setCursor(state: TablesState, action: TablesAction.SetCursor): TablesState {
-  const cursor = action.payload.cursor;
-
-  if (cursor && cursor.rowPath) {
-    const {table} = getTablePart(state, cursor);
-    if (table.parts.length === 1 && isLastInitializedRow(table, cursor)) {
-      const rows = table.rows.concat(EMPTY_TABLE_ROW);
-      return tablesAdapter.updateOne({id: table.id, changes: {rows}}, {...state, cursor});
-    }
-  }
-  return {...state, cursor};
-}
-
-function isLastInitializedRow(table: TableModel, cursor: TableBodyCursor): boolean {
-  return Boolean(cursor.rowPath.length === 1
-    && cursor.rowPath[0] === table.rows.length - 1
-    && table.rows[table.rows.length - 1].documentIds.length);
 }
 
 export function getTablePart(state: TablesState, cursor: TableHeaderCursor): { table: TableModel, part: TablePart } {

--- a/src/app/core/store/tables/tables.state.ts
+++ b/src/app/core/store/tables/tables.state.ts
@@ -64,6 +64,10 @@ export const selectTableCursorSelected = (cursor: TableCursor) => createSelector
   }
 });
 
+export const selectTableBySelectedCursor = createSelector(selectTablesDictionary, selectTableCursor, (tablesMap, cursor) => {
+  return cursor ? tablesMap[cursor.tableId] : null;
+});
+
 export const selectEditedAttribute = createSelector(selectTablesState, state => state.editedAttribute);
 export const selectAffected = (attribute: EditedAttribute) => createSelector(selectEditedAttribute, editedAttribute => {
   return attribute && editedAttribute &&

--- a/src/app/core/store/views/view.model.ts
+++ b/src/app/core/store/views/view.model.ts
@@ -18,16 +18,25 @@
  */
 
 import {Perspective} from '../../../view/perspectives/perspective';
+import {ResourceModel} from '../../model/resource.model';
 import {QueryModel} from '../navigation/query.model';
 import {SmartDocModel} from '../smartdoc/smartdoc.model';
 import {TableConfig} from '../tables/table.model';
-import {ResourceModel} from "../../model/resource.model";
 
 export interface ViewModel extends ResourceModel {
 
   perspective: Perspective;
   query: QueryModel;
   config: ViewConfigModel;
+
+}
+
+export interface ViewCursor {
+
+  linkInstanceId?: string;
+  collectionId: string;
+  documentId: string;
+  attributeId: string;
 
 }
 

--- a/src/app/core/store/views/views.action.ts
+++ b/src/app/core/store/views/views.action.ts
@@ -21,7 +21,7 @@ import {Action} from '@ngrx/store';
 import {QueryModel} from '../navigation/query.model';
 import {SmartDocModel} from '../smartdoc/smartdoc.model';
 import {TableConfig} from '../tables/table.model';
-import {DetailConfigModel, PostItConfigModel, SearchConfigModel, TableConfigModel, ViewConfigModel, ViewModel} from './view.model';
+import {DetailConfigModel, PostItConfigModel, SearchConfigModel, TableConfigModel, ViewConfigModel, ViewCursor, ViewModel} from './view.model';
 
 export enum ViewsActionType {
 
@@ -45,6 +45,8 @@ export enum ViewsActionType {
   CHANGE_SMARTDOC_CONFIG = '[Views] Change Smart Document Config',
   CHANGE_TABLE_CONFIG = '[Views] Change Table Config',
   CHANGE_TABLE2_CONFIG = '[Views] Change Table 2 Config',
+
+  SET_CURSOR = '[Views] Set Cursor',
 
   CLEAR = '[Views] Clear'
 
@@ -171,6 +173,13 @@ export namespace ViewsAction {
     }
   }
 
+  export class SetCursor implements Action {
+    public readonly type = ViewsActionType.SET_CURSOR;
+
+    public constructor(public payload: { cursor: ViewCursor }) {
+    }
+  }
+
   export class Clear implements Action {
     public readonly type = ViewsActionType.CLEAR;
 
@@ -182,6 +191,7 @@ export namespace ViewsAction {
     Create | CreateSuccess | CreateFailure |
     Update | UpdateSuccess | UpdateFailure |
     ChangeConfig | ChangeDetailConfig | ChangePostItConfig | ChangeSearchConfig | ChangeSmartDocConfig | ChangeTableConfig | ChangeTable2Config |
+    SetCursor |
     Clear;
 
 }

--- a/src/app/core/store/views/views.reducer.ts
+++ b/src/app/core/store/views/views.reducer.ts
@@ -42,6 +42,8 @@ export function viewsReducer(state: ViewsState = initialViewsState, action: View
       return {...state, config: {...state.config, table: action.payload.config}};
     case ViewsActionType.CHANGE_TABLE2_CONFIG:
       return {...state, config: {...state.config, table2: action.payload.config}};
+    case ViewsActionType.SET_CURSOR:
+      return {...state, cursor: action.payload.cursor};
     case ViewsActionType.CLEAR:
       return initialViewsState;
     default:

--- a/src/app/core/store/views/views.state.ts
+++ b/src/app/core/store/views/views.state.ts
@@ -21,13 +21,14 @@ import {createEntityAdapter, EntityState} from '@ngrx/entity';
 import {createSelector} from '@ngrx/store';
 import {AppState} from '../app.state';
 import {selectQuery} from '../navigation/navigation.state';
-import {ViewConfigModel, ViewModel} from './view.model';
-import {ViewFilters} from "./view.filters";
+import {ViewFilters} from './view.filters';
+import {ViewConfigModel, ViewCursor, ViewModel} from './view.model';
 
 export interface ViewsState extends EntityState<ViewModel> {
 
   loaded: boolean;
   config: ViewConfigModel;
+  cursor: ViewCursor;
 
 }
 
@@ -35,7 +36,8 @@ export const viewsAdapter = createEntityAdapter<ViewModel>({selectId: view => vi
 
 export const initialViewsState: ViewsState = viewsAdapter.getInitialState({
   loaded: false,
-  config: {}
+  config: {},
+  cursor: null
 });
 
 export const selectViewsState = (state: AppState) => state.views;
@@ -52,3 +54,5 @@ export const selectViewSmartDocConfig = createSelector(selectViewConfig, config 
 export const selectViewTableConfig = createSelector(selectViewConfig, config => config.table);
 export const selectViewTable2Config = createSelector(selectViewConfig, config => config.table2);
 export const selectViewsByQuery = createSelector(selectAllViews, selectQuery, (views, query): ViewModel[] => ViewFilters.filterByQuery(views, query));
+
+export const selectViewCursor = createSelector(selectViewsState, state => state.cursor);

--- a/src/app/dialog/create-link/create-link-dialog.component.ts
+++ b/src/app/dialog/create-link/create-link-dialog.component.ts
@@ -69,8 +69,6 @@ export class CreateLinkDialogComponent implements OnInit, OnDestroy {
   }
 
   public ngOnInit() {
-    this.form.reset();
-
     this.subscribeToLinkCollectionIds();
   }
 
@@ -84,7 +82,7 @@ export class CreateLinkDialogComponent implements OnInit, OnDestroy {
         withLatestFrom(this.store.select(selectAllCollections))
       ).subscribe(([linkCollectionIds, collections]) => {
         this.collections = collections.filter(collection => linkCollectionIds.includes(collection.id));
-        this.form.reset();
+        this.linkNameInput.setValue(this.collections.map(collection => collection.name).join('-'));
       })
     );
   }

--- a/src/app/dialog/dialog.service.ts
+++ b/src/app/dialog/dialog.service.ts
@@ -32,12 +32,14 @@ import {DialogPath} from './dialog-path';
 export class DialogService {
 
   public callback: any;
+  private open: boolean;
 
   public constructor(private router: Router) {
   }
 
   public closeDialog() {
     this.callback = null;
+    this.open = false;
     this.navigateToDialog(null);
   }
 
@@ -65,7 +67,12 @@ export class DialogService {
     this.navigateToDialog([DialogPath.SHARE_VIEW]);
   }
 
+  public isDialogOpen(): boolean {
+    return this.open;
+  }
+
   private navigateToDialog(path: any[]) {
+    this.open = true;
     return this.router.navigate(['', {outlets: {dialog: path}}], {queryParamsHandling: 'preserve'});
   }
 

--- a/src/app/shared/pipes/empty.pipe.ts
+++ b/src/app/shared/pipes/empty.pipe.ts
@@ -1,0 +1,31 @@
+/*
+ * Lumeer: Modern Data Definition and Processing Platform
+ *
+ * Copyright (C) since 2017 Answer Institute, s.r.o. and/or its affiliates.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {Pipe, PipeTransform} from '@angular/core';
+
+@Pipe({
+  name: 'empty'
+})
+export class EmptyPipe implements PipeTransform {
+
+  public transform(value: any[] | string): boolean {
+    return !value || value.length === 0;
+  }
+
+}

--- a/src/app/shared/pipes/filter-perspectives.pipe.ts
+++ b/src/app/shared/pipes/filter-perspectives.pipe.ts
@@ -1,0 +1,31 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {QueryModel} from '../../core/store/navigation/query.model';
+import {Perspective} from '../../view/perspectives/perspective';
+
+@Pipe({
+  name: 'filterPerspectives'
+})
+export class FilterPerspectivesPipe implements PipeTransform {
+
+  public transform(perspectives: Perspective[], query: QueryModel): Perspective[] {
+    return perspectives.filter(perspective => canShowPerspective(perspective, query));
+  }
+
+}
+
+function canShowPerspective(perspective: Perspective, query: QueryModel): boolean {
+  switch (perspective) {
+    case Perspective.Table2:
+    case Perspective.SmartDoc:
+    case Perspective.Chart:
+      return isSingleCollectionInQuery(query);
+    case Perspective.Table:
+      return false;
+    default:
+      return true;
+  }
+}
+
+function isSingleCollectionInQuery(query: QueryModel): boolean {
+  return query && query.collectionIds && query.collectionIds.length === 1;
+}

--- a/src/app/shared/pipes/perspective-icon.pipe.ts
+++ b/src/app/shared/pipes/perspective-icon.pipe.ts
@@ -1,0 +1,13 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {perspectiveIconsMap} from '../../view/perspectives/perspective';
+
+@Pipe({
+  name: 'perspectiveIcon'
+})
+export class PerspectiveIconPipe implements PipeTransform {
+
+  public transform(perspective: string): string {
+    return perspectiveIconsMap[perspective] || '';
+  }
+
+}

--- a/src/app/shared/pipes/pipes.module.ts
+++ b/src/app/shared/pipes/pipes.module.ts
@@ -27,6 +27,7 @@ import {NativeDatePipe} from './native-date.pipe';
 import {PerspectiveIconPipe} from './perspective-icon.pipe';
 import {PixelPipe} from './pixel.pipe';
 import {PrefixPipe} from './prefix.pipe';
+import { EmptyPipe } from './empty.pipe';
 
 @NgModule({
   imports: [
@@ -41,6 +42,7 @@ import {PrefixPipe} from './prefix.pipe';
     NativeDatePipe,
     PerspectiveIconPipe,
     FilterPerspectivesPipe,
+    EmptyPipe,
   ],
   exports: [
     LightenColorPipe,
@@ -51,6 +53,7 @@ import {PrefixPipe} from './prefix.pipe';
     NativeDatePipe,
     PerspectiveIconPipe,
     FilterPerspectivesPipe,
+    EmptyPipe,
   ]
 })
 export class PipesModule {

--- a/src/app/shared/pipes/pipes.module.ts
+++ b/src/app/shared/pipes/pipes.module.ts
@@ -20,11 +20,13 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {ColorsPipe} from './colors.pipe';
-import {PrefixPipe} from './prefix.pipe';
+import {FilterPerspectivesPipe} from './filter-perspectives.pipe';
 import {IconsPipe} from './icons.pipe';
-import {PixelPipe} from './pixel.pipe';
-import {NativeDatePipe} from './native-date.pipe';
 import {LightenColorPipe} from './lighten-color.pipe';
+import {NativeDatePipe} from './native-date.pipe';
+import {PerspectiveIconPipe} from './perspective-icon.pipe';
+import {PixelPipe} from './pixel.pipe';
+import {PrefixPipe} from './prefix.pipe';
 
 @NgModule({
   imports: [
@@ -36,7 +38,9 @@ import {LightenColorPipe} from './lighten-color.pipe';
     IconsPipe,
     ColorsPipe,
     PrefixPipe,
-    NativeDatePipe
+    NativeDatePipe,
+    PerspectiveIconPipe,
+    FilterPerspectivesPipe,
   ],
   exports: [
     LightenColorPipe,
@@ -44,7 +48,9 @@ import {LightenColorPipe} from './lighten-color.pipe';
     IconsPipe,
     ColorsPipe,
     PrefixPipe,
-    NativeDatePipe
+    NativeDatePipe,
+    PerspectiveIconPipe,
+    FilterPerspectivesPipe,
   ]
 })
 export class PipesModule {

--- a/src/app/shared/post-it-collections/post-it-collection.component/post-it-collection.component.html
+++ b/src/app/shared/post-it-collections/post-it-collection.component/post-it-collection.component.html
@@ -7,7 +7,7 @@
   <div class="card-body text-center">
     <a class="icon" [style.color]="collection.color"
        [title]="collection.name"
-       [routerLink]="collection.id ? [workspacePath(), 'view', 'postit'] : null"
+       [routerLink]="collection.id ? [workspacePath(), 'view', 'table'] : null"
        [queryParams]="collection.id ? { query: queryForCollectionDocuments() } : null"
        [attr.data-toggle]="collection.id ? '' : 'dropdown'">
       <i class="fa-6x {{ collection.icon }}" aria-hidden="true"></i>
@@ -21,7 +21,7 @@
     <div *ngIf="collection.id" class="document-count opacity-content clickable"
          [ngClass]="{'panel-visible' : focused}">
       <a title="Record Count" i18n-title="@@collection.document.count"
-         [routerLink]="[workspacePath(), 'view', 'postit']"
+         [routerLink]="[workspacePath(), 'view', 'table']"
          [queryParams]="{ query: queryForCollectionDocuments() }">
         <i class="far fa-file" aria-hidden="true"></i>&nbsp;{{ collection.documentsCount }}
       </a>

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -82,7 +82,8 @@ import {LinksModule} from "./links/links.module";
     ResourceHeaderComponent,
     DocumentModule,
     PreviewResultsModule,
-    LinksModule
+    LinksModule,
+    PipesModule,
   ]
 })
 export class SharedModule {

--- a/src/app/view/perspectives/perspective.ts
+++ b/src/app/view/perspectives/perspective.ts
@@ -19,12 +19,12 @@
 
 export enum Perspective {
   Detail = 'detail',
+  Search = 'search',
+  Table2 = 'table',
   PostIt = 'postit',
   Chart = 'chart',
-  Search = 'search',
   SmartDoc = 'smartdoc',
   Table = 'table-old',
-  Table2 = 'table'
 }
 
 export const perspectivesMap: { [id: string]: Perspective } = {

--- a/src/app/view/perspectives/search/documents/search-documents.component.ts
+++ b/src/app/view/perspectives/search/documents/search-documents.component.ts
@@ -30,11 +30,11 @@ import {DocumentModel} from '../../../../core/store/documents/document.model';
 import {DocumentsAction} from '../../../../core/store/documents/documents.action';
 import {selectDocumentsByQuery, selectDocumentsQueries} from '../../../../core/store/documents/documents.state';
 import {selectQuery} from '../../../../core/store/navigation/navigation.state';
+import {areQueriesEqual} from '../../../../core/store/navigation/query.helper';
 import {ViewsAction} from '../../../../core/store/views/views.action';
 import {selectViewSearchConfig} from '../../../../core/store/views/views.state';
 import {UserSettingsService} from '../../../../core/user-settings.service';
 import {SizeType} from '../../../../shared/slider/size-type';
-import {QueryHelper} from "../../../../core/store/navigation/query.helper";
 import {QueryModel} from "../../../../core/store/navigation/query.model";
 import {CollectionModel} from '../../../../core/store/collections/collection.model';
 import {selectCollectionsByQuery} from '../../../../core/store/collections/collections.state';
@@ -245,7 +245,7 @@ export class SearchDocumentsComponent implements OnInit, OnDestroy {
 
     const loadedSubscription = this.store.select(selectDocumentsQueries)
       .pipe(
-        map(queries => queries.filter(query => QueryHelper.equal(query, this.currentQuery)))
+        map(queries => queries.filter(query => areQueriesEqual(query, this.currentQuery)))
       )
       .subscribe(queries => this.loaded = queries && queries.length > 0);
     this.subscriptions.add(loadedSubscription);

--- a/src/app/view/perspectives/table2/body/rows/row/cell-group/cell/data-cell/table-data-cell.component.ts
+++ b/src/app/view/perspectives/table2/body/rows/row/cell-group/cell/data-cell/table-data-cell.component.ts
@@ -136,7 +136,9 @@ export class TableDataCellComponent implements OnChanges {
 
   public onEditEnd(value: string) {
     this.clearEditedAttribute();
-    this.saveData(value);
+    if (value) {
+      this.saveData(value);
+    }
   }
 
   private clearEditedAttribute() {

--- a/src/app/view/perspectives/table2/body/rows/row/cell-group/cell/data-cell/table-data-cell.component.ts
+++ b/src/app/view/perspectives/table2/body/rows/row/cell-group/cell/data-cell/table-data-cell.component.ts
@@ -261,7 +261,6 @@ export class TableDataCellComponent implements OnChanges {
     const cursor = {...this.cursor, rowPath};
 
     this.store.dispatch(new TablesAction.ReplaceRows({cursor, rows: [EMPTY_TABLE_ROW], deleteCount: 0}));
-    this.store.dispatch(new TablesAction.SetCursor({cursor: null}));
   }
 
   public onRemoveRow() {

--- a/src/app/view/perspectives/table2/body/rows/row/cell-group/cell/table-cell.component.html
+++ b/src/app/view/perspectives/table2/body/rows/row/cell-group/cell/table-cell.component.html
@@ -1,4 +1,5 @@
-<div [style.width]="column | columnWidth | pixel"
+<div [class.transparent-border-top]="cursor | isFirstRow"
+     [style.width]="column | columnWidth | pixel"
      (mousedown)="onMouseDown($event)"
      class="table-border-right table-border-bottom h-100">
   <ng-container *ngIf="column | isSingleColumn">

--- a/src/app/view/perspectives/table2/body/rows/row/cell-group/cell/table-cell.component.scss
+++ b/src/app/view/perspectives/table2/body/rows/row/cell-group/cell/table-cell.component.scss
@@ -1,0 +1,3 @@
+.transparent-border-top {
+  border-top: 1px solid transparent;
+}

--- a/src/app/view/perspectives/table2/body/rows/row/cell-group/cell/table-cell.component.ts
+++ b/src/app/view/perspectives/table2/body/rows/row/cell-group/cell/table-cell.component.ts
@@ -28,12 +28,11 @@ import {TableBodyCursor} from '../../../../../../../../core/store/tables/table-c
 import {TableModel, TableSingleColumn} from '../../../../../../../../core/store/tables/table.model';
 import {TablesAction} from '../../../../../../../../core/store/tables/tables.action';
 import {selectTableCursorSelected} from '../../../../../../../../core/store/tables/tables.state';
-import {Direction} from '../../../../../../../../shared/direction';
-import {KeyCode} from '../../../../../../../../shared/key-code';
 
 @Component({
   selector: 'table-cell',
   templateUrl: './table-cell.component.html',
+  styleUrls: ['./table-cell.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class TableCellComponent implements OnChanges {

--- a/src/app/view/perspectives/table2/body/rows/row/table-row.component.html
+++ b/src/app/view/perspectives/table2/body/rows/row/table-row.component.html
@@ -5,6 +5,7 @@
                      [table]="table"
                      [cursor]="cursor"
                      [row]="row"
+                     (click)="onRowNumberClick()"
                      class="table-border-right bg-white">
   </table-row-numbers>
 

--- a/src/app/view/perspectives/table2/body/rows/row/table-row.component.ts
+++ b/src/app/view/perspectives/table2/body/rows/row/table-row.component.ts
@@ -157,4 +157,8 @@ export class TableRowComponent implements OnChanges, OnDestroy {
     };
   }
 
+  public onRowNumberClick() {
+    this.store.dispatch(new TablesAction.SetCursor({cursor: null}));
+  }
+
 }

--- a/src/app/view/perspectives/table2/header/collection/table-header-collection.component.html
+++ b/src/app/view/perspectives/table2/header/collection/table-header-collection.component.html
@@ -1,6 +1,7 @@
 <div class="d-flex flex-column align-items-start">
   <table-caption [collection]="collection$ | async"
-                 [style.width]="part | partWidth | pixel">
+                 [style.width]="part | partWidth | pixel"
+                 (click)="onCaptionClick()">
   </table-caption>
   <table-column-group [table]="table"
                       [cursor]="cursor"

--- a/src/app/view/perspectives/table2/header/collection/table-header-collection.component.ts
+++ b/src/app/view/perspectives/table2/header/collection/table-header-collection.component.ts
@@ -25,6 +25,7 @@ import {CollectionModel} from '../../../../../core/store/collections/collection.
 import {selectCollectionById} from '../../../../../core/store/collections/collections.state';
 import {TableHeaderCursor} from '../../../../../core/store/tables/table-cursor';
 import {TableModel, TablePart} from '../../../../../core/store/tables/table.model';
+import {TablesAction} from '../../../../../core/store/tables/tables.action';
 
 @Component({
   selector: 'table-header-collection',
@@ -52,6 +53,10 @@ export class TableHeaderCollectionComponent implements OnChanges {
     if (changes.part && this.part) {
       this.collection$ = this.store.select(selectCollectionById(this.part.collectionId));
     }
+  }
+
+  public onCaptionClick() {
+    this.store.dispatch(new TablesAction.SetCursor({cursor: null}));
   }
 
 }

--- a/src/app/view/perspectives/table2/header/column-group/single-column/attribute-suggestions/table-attribute-suggestions.component.html
+++ b/src/app/view/perspectives/table2/header/column-group/single-column/attribute-suggestions/table-attribute-suggestions.component.html
@@ -1,6 +1,7 @@
-<div class="dropdown">
+<div *ngIf="!(collection | attributeExist:attributeName) || !(linkedAttributes$ | async | empty) || !(allAttributes$ | async | empty)"
+     class="dropdown">
   <div class="dropdown-menu show">
-    <ng-container *ngIf="!(collection | attributeExist:attributeName)">
+    <ng-container *ngIf="collection && !(collection | attributeExist:attributeName)">
       <div class="dropdown-header"
            i18n="@@table.header.suggestion.attribute.new">Create new attribute
       </div>
@@ -12,36 +13,43 @@
       </a>
     </ng-container>
 
-    <ng-container *ngIf="!(collection | attributeExist:attributeName) && (cursor | isLastPart:table) && !(table | embedded)">
-      <div class="dropdown-divider"></div>
-    </ng-container>
+    <div *ngIf="!(collection | attributeExist:attributeName) && (!(linkedAttributes$ | async | empty) || !(allAttributes$ | async | empty))"
+         class="dropdown-divider">
+    </div>
 
     <ng-container *ngIf="(cursor | isLastPart:table) && !(table | embedded)">
-      <div class="dropdown-header"
-           i18n="@@table.header.suggestion.link.existing">Use existing link
-      </div>
-      <a *ngFor="let linkedAttribute of linkedAttributes$ | async"
-         (mousedown)="useLinkType(linkedAttribute)"
-         class="dropdown-item">
-        <icons-presenter [colors]="[linkedAttribute.collection.color]"
-                         [icons]="[linkedAttribute.collection.icon]">
-        </icons-presenter>
-        <span>{{linkedAttribute.collection.name}}.</span><span [innerHtml]="linkedAttribute.attribute.name | highlight: lastName"></span>
-        <small class="text-secondary ml-1">({{linkedAttribute.linkType.name}})</small>
-      </a>
+      <ng-container *ngIf="!(linkedAttributes$ | async | empty)">
+        <div class="dropdown-header"
+             i18n="@@table.header.suggestion.link.existing">Use existing link
+        </div>
+        <a *ngFor="let linkedAttribute of linkedAttributes$ | async"
+           (mousedown)="useLinkType(linkedAttribute)"
+           class="dropdown-item">
+          <icons-presenter [colors]="[linkedAttribute.collection.color]"
+                           [icons]="[linkedAttribute.collection.icon]">
+          </icons-presenter>
+          <span>{{linkedAttribute.collection.name}}.</span><span [innerHtml]="linkedAttribute.attribute.name | highlight: lastName"></span>
+          <small class="text-secondary ml-1">({{linkedAttribute.linkType.name}})</small>
+        </a>
+      </ng-container>
 
-      <div class="dropdown-divider"></div>
-      <div class="dropdown-header"
-           i18n="@@table.header.suggestion.link.new">Create new link
+      <div *ngIf="!(linkedAttributes$ | async | empty) && !(allAttributes$ | async | empty)"
+           class="dropdown-divider">
       </div>
-      <a *ngFor="let linkedAttribute of allAttributes$ | async"
-         (mousedown)="createLinkType(linkedAttribute)"
-         class="dropdown-item">
-        <icons-presenter [colors]="[linkedAttribute.collection.color]"
-                         [icons]="[linkedAttribute.collection.icon]">
-        </icons-presenter>
-        <span>{{linkedAttribute.collection.name}}.</span><span [innerHtml]="linkedAttribute.attribute.name | highlight: lastName"></span>
-      </a>
+
+      <ng-container *ngIf="!(allAttributes$ | async | empty)">
+        <div class="dropdown-header"
+             i18n="@@table.header.suggestion.link.new">Create new link
+        </div>
+        <a *ngFor="let linkedAttribute of allAttributes$ | async"
+           (mousedown)="createLinkType(linkedAttribute)"
+           class="dropdown-item">
+          <icons-presenter [colors]="[linkedAttribute.collection.color]"
+                           [icons]="[linkedAttribute.collection.icon]">
+          </icons-presenter>
+          <span>{{linkedAttribute.collection.name}}.</span><span [innerHtml]="linkedAttribute.attribute.name | highlight: lastName"></span>
+        </a>
+      </ng-container>
     </ng-container>
   </div>
 </div>

--- a/src/app/view/perspectives/table2/header/column-group/single-column/table-single-column.component.html
+++ b/src/app/view/perspectives/table2/header/column-group/single-column/table-single-column.component.html
@@ -1,17 +1,16 @@
 <div (mousedown)="onMouseDown()"
      class="table-border-right table-border-bottom h-100">
-  <table-editable-cell *ngIf="attribute"
-                       [contextMenu]="contextMenuComponent?.contextMenu"
+  <table-editable-cell [contextMenu]="contextMenuComponent?.contextMenu"
                        [selected]="selected$ | async"
-                       [style.background]="collection | columnBackground:(attribute | attributeNameChanged:lastName)"
-                       [value]="attribute | attributeLastName"
+                       [style.background]="collection$ | async | columnBackground:(attribute$ | async | attributeNameChanged:lastName)"
+                       [value]="attribute$ | async | attributeLastName"
                        (valueChange)="onValueChange($event)"
                        (editStart)="onEditStart()"
                        (editEnd)="onEditEnd($event)"
                        class="d-block h-100 font-italic {{cursor | dragClass}}">
   </table-editable-cell>
-  <table-attribute-suggestions *ngIf="edited && attribute && !attribute.id && !(attribute | attributeParentName)"
-                               [attributeName]="attribute | attributeName:lastName"
+  <table-attribute-suggestions *ngIf="edited && !(attribute$ | async | entityCreated) && !(attribute$ | async | attributeParentName)"
+                               [attributeName]="attribute$ | async | attributeName:lastName"
                                [collection]="collection"
                                [cursor]="cursor"
                                [table]="table">
@@ -19,8 +18,8 @@
 </div>
 
 <table-column-context-menu #contextMenu
-                           *ngIf="attribute && cursor"
-                           [attribute]="attribute"
+                           *ngIf="(attribute$ | async) && cursor"
+                           [attribute]="attribute$ | async"
                            [cursor]="cursor"
                            [leaf]="leaf"
                            (add)="onAdd($event)"

--- a/src/app/view/perspectives/table2/header/column-group/single-column/table-single-column.component.html
+++ b/src/app/view/perspectives/table2/header/column-group/single-column/table-single-column.component.html
@@ -11,7 +11,7 @@
   </table-editable-cell>
   <table-attribute-suggestions *ngIf="edited && !(attribute$ | async | entityCreated) && !(attribute$ | async | attributeParentName)"
                                [attributeName]="attribute$ | async | attributeName:lastName"
-                               [collection]="collection"
+                               [collection]="collection$ | async"
                                [cursor]="cursor"
                                [table]="table">
   </table-attribute-suggestions>

--- a/src/app/view/perspectives/table2/header/column-group/single-column/table-single-column.component.ts
+++ b/src/app/view/perspectives/table2/header/column-group/single-column/table-single-column.component.ts
@@ -181,6 +181,9 @@ export class TableSingleColumnComponent implements OnInit, OnChanges {
 
   public onEditEnd(lastName: string) {
     this.edited = false;
+    if (!lastName) {
+      return;
+    }
 
     if (this.attributesSubscription) {
       this.attributesSubscription.unsubscribe();

--- a/src/app/view/perspectives/table2/header/column-group/single-column/table-single-column.component.ts
+++ b/src/app/view/perspectives/table2/header/column-group/single-column/table-single-column.component.ts
@@ -17,12 +17,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {ChangeDetectionStrategy, Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges, ViewChild} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnChanges, OnInit, SimpleChanges, ViewChild} from '@angular/core';
 import {Actions} from '@ngrx/effects';
 import {Action, Store} from '@ngrx/store';
 import {I18n} from '@ngx-translate/i18n-polyfill';
 import {Observable} from 'rxjs/Observable';
-import {tap} from 'rxjs/operators';
+import {first, map, tap} from 'rxjs/operators';
 import {Subscription} from 'rxjs/Subscription';
 import {AppState} from '../../../../../../core/store/app.state';
 import {AttributeModel, CollectionModel} from '../../../../../../core/store/collections/collection.model';
@@ -46,7 +46,7 @@ import {TableColumnContextMenuComponent} from './context-menu/table-column-conte
   templateUrl: './table-single-column.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class TableSingleColumnComponent implements OnInit, OnChanges, OnDestroy {
+export class TableSingleColumnComponent implements OnInit, OnChanges {
 
   @Input()
   public table: TableModel;
@@ -66,20 +66,24 @@ export class TableSingleColumnComponent implements OnInit, OnChanges, OnDestroy 
   @ViewChild(TableColumnContextMenuComponent)
   public contextMenuComponent: TableColumnContextMenuComponent;
 
-  public collection: CollectionModel;
-  public linkType: LinkTypeModel;
+  public collection$: Observable<CollectionModel>;
+  public linkType$: Observable<LinkTypeModel>;
+  public attributes$: Observable<AttributeModel[]>;
+  public attribute$: Observable<AttributeModel>;
 
-  public attribute: AttributeModel;
+  public collectionId: string;
+  public linkTypeId: string;
   public lastName: string;
 
   public selected$: Observable<boolean>;
   public edited: boolean;
 
   private editSubscription: Subscription;
-  public subscriptions: Subscription = new Subscription();
+  private attributesSubscription: Subscription;
 
   public constructor(private actions$: Actions,
                      private attributeNameChangedPipe: AttributeNameChangedPipe,
+                     private changeDetector: ChangeDetectorRef,
                      private i18n: I18n,
                      private store: Store<AppState>) {
   }
@@ -89,35 +93,39 @@ export class TableSingleColumnComponent implements OnInit, OnChanges, OnDestroy 
   }
 
   private loadEntity() {
-    if (this.getPart().collectionId) {
-      this.loadCollection();
+    const part = this.getPart();
+    if (part.collectionId) {
+      this.collection$ = this.loadCollection(part.collectionId);
+      this.attributes$ = this.collection$.pipe(
+        map(collection => collection.attributes)
+      );
     }
-    if (this.getPart().linkTypeId) {
-      this.loadLinkType();
+    if (part.linkTypeId) {
+      this.linkType$ = this.loadLinkType(part.linkTypeId);
+      this.attributes$ = this.linkType$.pipe(
+        map(linkType => linkType.attributes)
+      );
     }
-  }
-
-  private loadCollection() {
-    this.subscriptions.add(
-      this.store.select(selectCollectionById(this.getPart().collectionId)).subscribe(collection => {
-        this.collection = collection;
-        this.initializeAttribute(this.collection.attributes);
+    this.attribute$ = this.attributes$.pipe(
+      map(attributes => this.findAttribute(attributes) || {name: this.column.attributeName, constraints: []}),
+      tap(attribute => {
+        if (attribute && !this.lastName) {
+          this.lastName = extractAttributeLastName(attribute.name);
+        }
       })
     );
   }
 
-  private loadLinkType() {
-    this.subscriptions.add(
-      this.store.select(selectLinkTypeById(this.getPart().linkTypeId)).subscribe(linkType => {
-        this.linkType = linkType;
-        this.initializeAttribute(this.linkType.attributes);
-      })
+  private loadCollection(collectionId: string): Observable<CollectionModel> {
+    return this.store.select(selectCollectionById(collectionId)).pipe(
+      tap(collection => this.collectionId = collection.id)
     );
   }
 
-  private initializeAttribute(attributes: AttributeModel[]) {
-    this.attribute = this.findAttribute(attributes) || {name: this.column.attributeName, constraints: []};
-    this.lastName = extractAttributeLastName(this.attribute.name);
+  private loadLinkType(linkTypeId: string): Observable<LinkTypeModel> {
+    return this.store.select(selectLinkTypeById(linkTypeId)).pipe(
+      tap(linkType => this.linkTypeId = linkType.id)
+    );
   }
 
   public ngOnChanges(changes: SimpleChanges) {
@@ -151,7 +159,12 @@ export class TableSingleColumnComponent implements OnInit, OnChanges, OnDestroy 
   }
 
   public ngOnDestroy() {
-    this.subscriptions.unsubscribe();
+    if (this.editSubscription) {
+      this.editSubscription.unsubscribe();
+    }
+    if (this.attributesSubscription) {
+      this.attributesSubscription.unsubscribe();
+    }
   }
 
   private findAttribute(attributes: AttributeModel[]) {
@@ -169,26 +182,35 @@ export class TableSingleColumnComponent implements OnInit, OnChanges, OnDestroy 
   public onEditEnd(lastName: string) {
     this.edited = false;
 
-    if (this.attributeNameChangedPipe.transform(this.attribute, lastName) && this.isUniqueAttributeName(lastName)) {
-      this.renameAttribute(lastName);
+    if (this.attributesSubscription) {
+      this.attributesSubscription.unsubscribe();
     }
+    this.attributesSubscription = Observable.combineLatest(this.attributes$, this.attribute$).pipe(
+      first()
+    ).subscribe(([attributes, attribute]) => {
+      if (this.attributeNameChangedPipe.transform(attribute, lastName)
+        && this.isUniqueAttributeName(attributes, attribute ? attribute.id : null, lastName)) {
+        this.renameAttribute(attribute, lastName);
+        setTimeout(() => this.changeDetector.detectChanges());
+      }
+    });
   }
 
-  private renameAttribute(lastName: string) {
-    const parentName = extractAttributeParentName(this.attribute.name);
+  private renameAttribute(oldAttribute: AttributeModel, lastName: string) {
+    const parentName = extractAttributeParentName(oldAttribute.name);
     const name = parentName ? `${parentName}.${lastName}` : lastName;
-    const attribute = {...this.attribute, name};
+    const attribute = {...oldAttribute, name};
 
-    if (this.collection) {
+    if (this.collectionId) {
       this.renameCollectionAttribute(attribute);
     }
-    if (this.linkType) {
+    if (this.linkTypeId) {
       // TODO
     }
   }
 
   private renameCollectionAttribute(attribute: AttributeModel) {
-    if (this.attribute.id) {
+    if (attribute.id) {
       this.updateCollectionAttribute(attribute);
     } else {
       this.createCollectionAttribute(attribute);
@@ -202,7 +224,7 @@ export class TableSingleColumnComponent implements OnInit, OnChanges, OnDestroy 
     });
 
     this.store.dispatch(new CollectionsAction.CreateAttributes({
-      collectionId: this.collection.id,
+      collectionId: this.collectionId,
       attributes: [attribute],
       nextAction
     }));
@@ -210,25 +232,25 @@ export class TableSingleColumnComponent implements OnInit, OnChanges, OnDestroy 
 
   private updateCollectionAttribute(attribute: AttributeModel) {
     this.store.dispatch(new CollectionsAction.ChangeAttribute({
-      collectionId: this.collection.id,
-      attributeId: this.attribute.id,
+      collectionId: this.collectionId,
+      attributeId: attribute.id,
       attribute
     }));
   }
 
-  public isUniqueAttributeName(lastName: string): boolean {
+  public isUniqueAttributeName(attributes: AttributeModel[], attributeId: string, lastName: string): boolean {
     if (this.cursor.columnPath.length === 1) {
-      return filterAttributesByDepth(this.getAttributes(), 1)
-        .filter(attribute => this.attribute.id !== attribute.id)
+      return filterAttributesByDepth(attributes, 1)
+        .filter(attribute => attributeId !== attribute.id)
         .every(attribute => attribute.name !== lastName);
     }
 
     const parentColumn = findTableColumn(this.getPart().columns, this.cursor.columnPath.slice(0, -1)) as TableCompoundColumn;
-    const parentAttribute = this.getAttributes().find(attribute => attribute.id === parentColumn.parent.attributeId);
+    const parentAttribute = attributes.find(attribute => attribute.id === parentColumn.parent.attributeId);
     const prefix = `${parentAttribute.name}.`;
-    return this.getAttributes()
+    return attributes
       .filter(attribute => attribute.name.startsWith(prefix))
-      .filter(attribute => this.attribute.id !== attribute.id)
+      .filter(attribute => attributeId !== attribute.id)
       .every(attribute => extractAttributeLastName(attribute.name) !== lastName);
   }
 
@@ -252,11 +274,16 @@ export class TableSingleColumnComponent implements OnInit, OnChanges, OnDestroy 
   }
 
   public onRemove() {
-    if (this.attribute) {
-      this.showRemoveConfirm();
-    } else {
-      this.removeUninitializedColumn();
+    if (this.attributesSubscription) {
+      this.attributesSubscription.unsubscribe();
     }
+    this.attributesSubscription = this.attribute$.subscribe(attribute => {
+      if (attribute) { // TODO probably id condition?
+        this.showRemoveConfirm();
+      } else {
+        this.removeUninitializedColumn();
+      }
+    });
   }
 
   private showRemoveConfirm() {
@@ -274,16 +301,6 @@ export class TableSingleColumnComponent implements OnInit, OnChanges, OnDestroy 
 
   private removeUninitializedColumn() {
     this.store.dispatch(new TablesAction.RemoveColumn({cursor: this.cursor}));
-  }
-
-  private getAttributes(): AttributeModel[] {
-    if (this.collection) {
-      return this.collection.attributes;
-    }
-    if (this.linkType) {
-      return this.linkType.attributes;
-    }
-    return [];
   }
 
   public onMouseDown() {

--- a/src/app/view/perspectives/table2/header/column-group/single-column/table-single-column.component.ts
+++ b/src/app/view/perspectives/table2/header/column-group/single-column/table-single-column.component.ts
@@ -36,6 +36,7 @@ import {TableCompoundColumn, TableModel, TablePart, TableSingleColumn} from '../
 import {findTableColumn, splitColumnPath} from '../../../../../../core/store/tables/table.utils';
 import {TablesAction, TablesActionType} from '../../../../../../core/store/tables/tables.action';
 import {selectTableCursorSelected} from '../../../../../../core/store/tables/tables.state';
+import {DialogService} from '../../../../../../dialog/dialog.service';
 import {extractAttributeLastName, extractAttributeParentName, filterAttributesByDepth} from '../../../../../../shared/utils/attribute.utils';
 import {TableEditableCellComponent} from '../../../shared/editable-cell/table-editable-cell.component';
 import {AttributeNameChangedPipe} from '../../../shared/pipes/attribute-name-changed.pipe';
@@ -84,6 +85,7 @@ export class TableSingleColumnComponent implements OnInit, OnChanges {
   public constructor(private actions$: Actions,
                      private attributeNameChangedPipe: AttributeNameChangedPipe,
                      private changeDetector: ChangeDetectorRef,
+                     private dialogService: DialogService,
                      private i18n: I18n,
                      private store: Store<AppState>) {
   }
@@ -181,7 +183,7 @@ export class TableSingleColumnComponent implements OnInit, OnChanges {
 
   public onEditEnd(lastName: string) {
     this.edited = false;
-    if (!lastName) {
+    if (!lastName || this.dialogService.isDialogOpen()) {
       return;
     }
 

--- a/src/app/view/perspectives/table2/header/column-group/single-column/table-single-column.component.ts
+++ b/src/app/view/perspectives/table2/header/column-group/single-column/table-single-column.component.ts
@@ -281,7 +281,7 @@ export class TableSingleColumnComponent implements OnInit, OnChanges {
       this.attributesSubscription.unsubscribe();
     }
     this.attributesSubscription = this.attribute$.subscribe(attribute => {
-      if (attribute) { // TODO probably id condition?
+      if (attribute && attribute.id) {
         this.showRemoveConfirm();
       } else {
         this.removeUninitializedColumn();

--- a/src/app/view/perspectives/table2/header/column-group/single-column/table-single-column.component.ts
+++ b/src/app/view/perspectives/table2/header/column-group/single-column/table-single-column.component.ts
@@ -22,7 +22,7 @@ import {Actions} from '@ngrx/effects';
 import {Action, Store} from '@ngrx/store';
 import {I18n} from '@ngx-translate/i18n-polyfill';
 import {Observable} from 'rxjs/Observable';
-import {first, tap} from 'rxjs/operators';
+import {tap} from 'rxjs/operators';
 import {Subscription} from 'rxjs/Subscription';
 import {AppState} from '../../../../../../core/store/app.state';
 import {AttributeModel, CollectionModel} from '../../../../../../core/store/collections/collection.model';
@@ -32,11 +32,11 @@ import {LinkTypeModel} from '../../../../../../core/store/link-types/link-type.m
 import {selectLinkTypeById} from '../../../../../../core/store/link-types/link-types.state';
 import {NotificationsAction} from '../../../../../../core/store/notifications/notifications.action';
 import {areTableHeaderCursorsEqual, TableHeaderCursor} from '../../../../../../core/store/tables/table-cursor';
-import {TableColumn, TableCompoundColumn, TableModel, TablePart, TableSingleColumn} from '../../../../../../core/store/tables/table.model';
+import {TableCompoundColumn, TableModel, TablePart, TableSingleColumn} from '../../../../../../core/store/tables/table.model';
 import {findTableColumn, splitColumnPath} from '../../../../../../core/store/tables/table.utils';
 import {TablesAction, TablesActionType} from '../../../../../../core/store/tables/tables.action';
 import {selectTableCursorSelected} from '../../../../../../core/store/tables/tables.state';
-import {extractAttributeLastName, extractAttributeParentName, filterAttributesByDepth, generateAttributeName, splitAttributeName} from '../../../../../../shared/utils/attribute.utils';
+import {extractAttributeLastName, extractAttributeParentName, filterAttributesByDepth} from '../../../../../../shared/utils/attribute.utils';
 import {TableEditableCellComponent} from '../../../shared/editable-cell/table-editable-cell.component';
 import {AttributeNameChangedPipe} from '../../../shared/pipes/attribute-name-changed.pipe';
 import {TableColumnContextMenuComponent} from './context-menu/table-column-context-menu.component';
@@ -133,15 +133,6 @@ export class TableSingleColumnComponent implements OnInit, OnChanges, OnDestroy 
         this.edited = selected ? this.edited : false;
 
         this.bindOrUnbindEditSelectedCell(selected);
-
-        // TODO probably better to do in action
-        if (selected && this.table.parts.length === 1 && this.cursor.columnPath.length === 1
-          && this.cursor.columnPath[0] === this.getPart().columns.length - 1 && this.attribute && this.attribute.id) {
-          const attributeName = generateAttributeName(this.getAttributes());
-          const column = new TableCompoundColumn(new TableSingleColumn(null, attributeName), []);
-          const cursor = {...this.cursor, columnPath: [this.cursor.columnPath[0] + 1]};
-          this.store.dispatch(new TablesAction.AddColumn({cursor, column}));
-        }
       })
     );
   }
@@ -245,13 +236,7 @@ export class TableSingleColumnComponent implements OnInit, OnChanges, OnDestroy 
     const {parentPath, columnIndex} = splitColumnPath(this.cursor.columnPath);
     const columnPath = parentPath.concat(columnIndex + (next ? 1 : 0));
     const cursor = {...this.cursor, columnPath};
-    this.store.dispatch(new TablesAction.AddColumn({cursor, column: this.createNewColumn()}));
-  }
-
-  private createNewColumn(): TableColumn {
-    const {parentName} = splitAttributeName(this.column.attributeId);
-    const attributeName = generateAttributeName(this.getAttributes(), parentName);
-    return new TableCompoundColumn(new TableSingleColumn(null, attributeName), []);
+    this.store.dispatch(new TablesAction.AddColumn({cursor}));
   }
 
   public onEdit() {

--- a/src/app/view/perspectives/table2/header/table-header.component.html
+++ b/src/app/view/perspectives/table2/header/table-header.component.html
@@ -1,6 +1,7 @@
 <div class="d-flex">
   <div [style.min-width]="table | rowNumberWidth"
-       [style.width]="table | rowNumberWidth"></div>
+       [style.width]="table | rowNumberWidth"
+       (click)="onRowNumberColumnClick()"></div>
   <ng-container *ngFor="let part of table.parts; trackBy: trackByPartIndex">
     <table-header-collection *ngIf="part.collectionId"
                              [cursor]="cursor | partCursor:part.index"

--- a/src/app/view/perspectives/table2/header/table-header.component.ts
+++ b/src/app/view/perspectives/table2/header/table-header.component.ts
@@ -18,8 +18,11 @@
  */
 
 import {ChangeDetectionStrategy, Component, Input, SimpleChange, SimpleChanges} from '@angular/core';
+import {Store} from '@ngrx/store';
+import {AppState} from '../../../../core/store/app.state';
 import {TableHeaderCursor} from '../../../../core/store/tables/table-cursor';
 import {TableModel, TablePart} from '../../../../core/store/tables/table.model';
+import {TablesAction} from '../../../../core/store/tables/tables.action';
 
 @Component({
   selector: 'table-header',
@@ -33,6 +36,9 @@ export class TableHeaderComponent {
   public table: TableModel;
 
   public cursor: TableHeaderCursor;
+
+  public constructor(private store: Store<AppState>) {
+  }
 
   public ngOnChanges(changes: SimpleChanges): void {
     if (changes.table && this.table && hasTableIdChanged(changes.table)) {
@@ -50,6 +56,10 @@ export class TableHeaderComponent {
 
   public trackByPartIndex(index: number, part: TablePart): number {
     return part.index;
+  }
+
+  public onRowNumberColumnClick() {
+    this.store.dispatch(new TablesAction.SetCursor({cursor: null}));
   }
 
 }

--- a/src/app/view/perspectives/table2/shared/editable-cell/table-editable-cell.component.scss
+++ b/src/app/view/perspectives/table2/shared/editable-cell/table-editable-cell.component.scss
@@ -3,6 +3,7 @@
 %highlighted {
   position: relative;
   z-index: $z-index-selected;
+  outline-offset: -1px;
 }
 
 .selected {

--- a/src/app/view/perspectives/table2/shared/editable-cell/table-editable-cell.component.ts
+++ b/src/app/view/perspectives/table2/shared/editable-cell/table-editable-cell.component.ts
@@ -84,9 +84,12 @@ export class TableEditableCellComponent implements OnChanges {
     event.stopPropagation();
     switch (event.keyCode) {
       case KeyCode.Enter:
-      case KeyCode.Escape:
       case KeyCode.F2:
         this.stopEditing();
+        event.preventDefault();
+        return;
+      case KeyCode.Escape:
+        this.stopEditing(true);
         event.preventDefault();
         return;
     }
@@ -105,7 +108,7 @@ export class TableEditableCellComponent implements OnChanges {
     this.edited = true;
 
     const element = this.editableCell.nativeElement;
-    if (letter && !element.textContent) {
+    if (letter) {
       element.textContent = letter;
     }
 
@@ -113,15 +116,21 @@ export class TableEditableCellComponent implements OnChanges {
     setTimeout(() => HtmlModifier.setCursorAtTextContentEnd(this.editableCell.nativeElement));
   }
 
-  private stopEditing() {
+  private stopEditing(cancel?: boolean) {
     if (!this.edited || this.readonly) {
       return;
     }
 
     this.edited = false;
 
-    const value = this.editableCell.nativeElement.textContent;
-    this.editEnd.emit(value);
+    if (cancel) {
+      this.editableCell.nativeElement.textContent = this.value;
+      this.valueChange.emit(this.value);
+      this.editEnd.emit();
+    } else {
+      const value = this.editableCell.nativeElement.textContent;
+      this.editEnd.emit(value);
+    }
   }
 
 }

--- a/src/app/view/perspectives/table2/shared/pipes/attribute-last-name.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/attribute-last-name.pipe.ts
@@ -8,7 +8,7 @@ import {extractAttributeLastName} from '../../../../../shared/utils/attribute.ut
 export class AttributeLastNamePipe implements PipeTransform {
 
   public transform(attribute: AttributeModel): string {
-    return extractAttributeLastName(attribute.name);
+    return attribute && extractAttributeLastName(attribute.name);
   }
 
 }

--- a/src/app/view/perspectives/table2/shared/pipes/is-first-row.pipe.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/is-first-row.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import {TableBodyCursor} from '../../../../../core/store/tables/table-cursor';
+
+@Pipe({
+  name: 'isFirstRow'
+})
+export class IsFirstRowPipe implements PipeTransform {
+
+  public transform(cursor: TableBodyCursor): boolean {
+    return cursor && cursor.rowPath && cursor.rowPath[0] === 0;
+  }
+
+}

--- a/src/app/view/perspectives/table2/shared/pipes/table-pipes.module.ts
+++ b/src/app/view/perspectives/table2/shared/pipes/table-pipes.module.ts
@@ -50,6 +50,7 @@ import {PartWidthPipe} from './part-width.pipe';
 import {PartPipe} from './part.pipe';
 import {ResizeEdgesPipe} from './resize-edges.pipe';
 import {RowNumberWidthPipe} from './row-number-width.pipe';
+import { IsFirstRowPipe } from './is-first-row.pipe';
 
 @NgModule({
   imports: [
@@ -86,7 +87,8 @@ import {RowNumberWidthPipe} from './row-number-width.pipe';
     AttributeNamePipe,
     AttributeParentNamePipe,
     AttributeExistPipe,
-    EmbeddedPipe
+    EmbeddedPipe,
+    IsFirstRowPipe
   ], exports: [
     DataPipe,
     EntityCreatedPipe,
@@ -118,7 +120,8 @@ import {RowNumberWidthPipe} from './row-number-width.pipe';
     AttributeNamePipe,
     AttributeParentNamePipe,
     AttributeExistPipe,
-    EmbeddedPipe
+    EmbeddedPipe,
+    IsFirstRowPipe
   ],
   providers: [
     AttributeNameChangedPipe

--- a/src/app/view/perspectives/table2/table2-perspective.component.html
+++ b/src/app/view/perspectives/table2/table2-perspective.component.html
@@ -10,10 +10,12 @@
      class="table d-flex flex-column align-items-start m-0">
   <div (clickOutside)="onClickOutside()"
        class="d-flex flex-column">
-    <table-header [table]="table">
+    <table-header [table]="table"
+                  class="d-block pr-4">
     </table-header>
     <table-body [table]="table"
-                [query]="query">
+                [query]="query"
+                class="d-block pr-4 pb-4">
     </table-body>
   </div>
   <div class="flex-grow-1"></div>

--- a/src/app/view/perspectives/table2/table2-perspective.component.html
+++ b/src/app/view/perspectives/table2/table2-perspective.component.html
@@ -7,11 +7,14 @@
 <div #positioner></div>
 <div *ngIf="query | displayable"
      [style.height]="height"
-     (clickOutside)="onClickOutside()"
-     class="table d-flex flex-column m-0">
-  <table-header [table]="table">
-  </table-header>
-  <table-body [table]="table"
-              [query]="query">
-  </table-body>
+     class="table d-flex flex-column align-items-start m-0">
+  <div (clickOutside)="onClickOutside()"
+       class="d-flex flex-column">
+    <table-header [table]="table">
+    </table-header>
+    <table-body [table]="table"
+                [query]="query">
+    </table-body>
+  </div>
+  <div class="flex-grow-1"></div>
 </div>

--- a/src/app/view/perspectives/table2/table2-perspective.component.html
+++ b/src/app/view/perspectives/table2/table2-perspective.component.html
@@ -8,7 +8,7 @@
 <div *ngIf="query | displayable"
      [style.height]="height"
      class="table d-flex flex-column align-items-start m-0">
-  <div (clickOutside)="onClickOutside()"
+  <div (clickOutside)="onClickOutside($event)"
        class="d-flex flex-column">
     <table-header [table]="table"
                   class="d-block pr-4">

--- a/src/app/view/perspectives/table2/table2-perspective.component.ts
+++ b/src/app/view/perspectives/table2/table2-perspective.component.ts
@@ -33,6 +33,7 @@ import {selectTableById, selectTableCursor} from '../../../core/store/tables/tab
 import {Direction} from '../../../shared/direction';
 import {KeyCode} from '../../../shared/key-code';
 import {isKeyPrintable} from '../../../shared/utils/key-code.helper';
+import {PERSPECTIVE_CHOOSER_CLICK} from '../../view-controls/view-controls.component';
 import {Perspective} from '../perspective';
 import CreateTable = TablesAction.CreateTable;
 import DestroyTable = TablesAction.DestroyTable;
@@ -153,8 +154,8 @@ export class Table2PerspectiveComponent implements OnInit, OnDestroy {
     return this.linkInstance ? this.linkInstance.id : DEFAULT_TABLE_ID;
   }
 
-  public onClickOutside() {
-    if (this.selectedCursor) {
+  public onClickOutside(event: MouseEvent) {
+    if (this.selectedCursor && !event[PERSPECTIVE_CHOOSER_CLICK]) {
       this.store.dispatch(new TablesAction.SetCursor({cursor: null}));
     }
   }

--- a/src/app/view/perspectives/table2/table2-perspective.component.ts
+++ b/src/app/view/perspectives/table2/table2-perspective.component.ts
@@ -24,7 +24,7 @@ import {Subscription} from 'rxjs/Subscription';
 import {AppState} from '../../../core/store/app.state';
 import {LinkInstanceModel} from '../../../core/store/link-instances/link-instance.model';
 import {selectNavigation} from '../../../core/store/navigation/navigation.state';
-import {getNewLinkTypeIdFromQuery, hasQueryNewLink} from '../../../core/store/navigation/query.helper';
+import {areQueriesEqual, getNewLinkTypeIdFromQuery, hasQueryNewLink} from '../../../core/store/navigation/query.helper';
 import {QueryModel} from '../../../core/store/navigation/query.model';
 import {TableCursor} from '../../../core/store/tables/table-cursor';
 import {DEFAULT_TABLE_ID, TableModel} from '../../../core/store/tables/table.model';
@@ -124,6 +124,10 @@ export class Table2PerspectiveComponent implements OnInit, OnDestroy {
       this.store.select(selectNavigation).pipe(
         filter(navigation => navigation.perspective === Perspective.Table2 && !!navigation.query)
       ).subscribe(({query}) => {
+        if (areQueriesEqual(this.query, query)) {
+          return;
+        }
+
         if (this.table && hasQueryNewLink(this.query, query)) {
           this.addTablePart(query);
         } else {

--- a/src/app/view/view-controls/view-controls.component.html
+++ b/src/app/view/view-controls/view-controls.component.html
@@ -1,5 +1,6 @@
 <form class="form-inline d-flex flex-nowrap">
-  <div class="form-control dropdown mr-2 p-0" title="Perspective" i18n-title="@@view.perspective">
+  <div (click)="onPerspectiveChooserClick($event)"
+       class="form-control dropdown mr-2 p-0" title="Perspective" i18n-title="@@view.perspective">
     <div class="dropdown-toggle py-1 px-2 d-flex flex-nowrap align-items-center"
          id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       <i class="fa-fw {{perspective | perspectiveIcon}}"></i>

--- a/src/app/view/view-controls/view-controls.component.html
+++ b/src/app/view/view-controls/view-controls.component.html
@@ -2,15 +2,14 @@
   <div class="form-control dropdown mr-2 p-0" title="Perspective" i18n-title="@@view.perspective">
     <div class="dropdown-toggle py-1 px-2 d-flex flex-nowrap align-items-center"
          id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      <i class="fa-fw {{getIconForPerspective(perspective)}}"></i>
+      <i class="fa-fw {{perspective | perspectiveIcon}}"></i>
       <span class="ml-1 text-nowrap" i18n="@@view.perspective.name">{perspective, select, detail {Detail} postit {Post-it} chart {Chart} search {Search} table {Table} table2 {Table 2} smartdoc {Smart document}}</span>
     </div>
     <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-      <ng-container *ngFor="let perspective of perspectives()">
-        <div *ngIf="canShowPerspective(perspective)"
-             class="dropdown-item"
-             (click)="onSelectPerspective(perspective)">
-          <i class="fa-fw {{getIconForPerspective(perspective)}}"></i>
+      <ng-container *ngFor="let perspective of perspectives | filterPerspectives:view.query">
+        <div (click)="onSelectPerspective(perspective)"
+             class="dropdown-item">
+          <i class="fa-fw {{perspective | perspectiveIcon}}"></i>
           <span class="ml-1 text-nowrap" i18n="@@view.perspective.name">{perspective, select, detail {Detail} postit {Post-it} chart {Chart} search {Search} table {Table} table2 {Table 2} smartdoc {Smart document}}</span>
         </div>
       </ng-container>

--- a/src/app/view/view-controls/view-controls.component.ts
+++ b/src/app/view/view-controls/view-controls.component.ts
@@ -18,9 +18,10 @@
  */
 
 import {Component, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, ViewChild} from '@angular/core';
-import {Router} from '@angular/router';
 import {Store} from '@ngrx/store';
+import {I18n} from '@ngx-translate/i18n-polyfill';
 import {Subscription} from 'rxjs';
+import {NotificationService} from '../../core/notifications/notification.service';
 import {AppState} from '../../core/store/app.state';
 import {selectNavigation} from '../../core/store/navigation/navigation.state';
 import {QueryConverter} from '../../core/store/navigation/query.converter';
@@ -30,10 +31,7 @@ import {ViewModel} from '../../core/store/views/view.model';
 import {ViewsAction} from '../../core/store/views/views.action';
 import {selectViewConfig} from '../../core/store/views/views.state';
 import {DialogService} from '../../dialog/dialog.service';
-import {Perspective, perspectiveIconsMap} from '../perspectives/perspective';
-import {NotificationService} from "../../core/notifications/notification.service";
-import {I18n} from "@ngx-translate/i18n-polyfill";
-import {SnotifyStyle} from "ng-snotify/snotify/enums/SnotifyStyle.enum";
+import {Perspective} from '../perspectives/perspective';
 
 @Component({
   selector: 'view-controls',
@@ -56,6 +54,7 @@ export class ViewControlsComponent implements OnInit, OnChanges, OnDestroy {
 
   private workspace: Workspace;
   public perspective: Perspective;
+  public perspectives = Object.values(Perspective);
 
   private configSubscription: Subscription;
   private navigationSubscription: Subscription;
@@ -161,32 +160,6 @@ export class ViewControlsComponent implements OnInit, OnChanges, OnDestroy {
       {text: okButtonText, bold: true},
     ]);
     //this.dialogService.openShareViewDialog();
-  }
-
-  public perspectives(): string[] {
-    return Object.values(Perspective);
-  }
-
-  public getIconForPerspective(perspective: string): string {
-    return perspectiveIconsMap[perspective] || '';
-  }
-
-  private isSingleCollectionInQuery(): boolean {
-    const query = this.view.query;
-    return query && query.collectionIds && query.collectionIds.length === 1;
-  }
-
-  public canShowPerspective(perspective: Perspective): boolean {
-    switch (perspective) {
-      case Perspective.Table2:
-      case Perspective.SmartDoc:
-      case Perspective.Chart:
-        return this.isSingleCollectionInQuery();
-      case Perspective.Table:
-        return false;
-      default:
-        return true;
-    }
   }
 
   private dispatchActionsOnChangePerspective(perspective: string) {

--- a/src/app/view/view-controls/view-controls.component.ts
+++ b/src/app/view/view-controls/view-controls.component.ts
@@ -33,6 +33,8 @@ import {selectViewConfig} from '../../core/store/views/views.state';
 import {DialogService} from '../../dialog/dialog.service';
 import {Perspective} from '../perspectives/perspective';
 
+export const PERSPECTIVE_CHOOSER_CLICK = 'perspectiveChooserClick';
+
 @Component({
   selector: 'view-controls',
   templateUrl: './view-controls.component.html',
@@ -166,6 +168,10 @@ export class ViewControlsComponent implements OnInit, OnChanges, OnDestroy {
     if (perspective === Perspective.Search.valueOf()) {
       this.store.dispatch(new ViewsAction.ChangeSearchConfig({config: {expandedDocumentIds: []}}));
     }
+  }
+
+  public onPerspectiveChooserClick(event: MouseEvent) {
+    event[PERSPECTIVE_CHOOSER_CLICK] = true;
   }
 
 }


### PR DESCRIPTION
I have fixed some table UX issues:
- [x] open collection in table perspective by default
- [x] change order of shown perspectives
- [x] fix selected table cell border
- [x] create new column and row properly on last selected
- [x] hide uninitialized columns/rows on cursor lose
- [x] remove striped background on attribute edit success
- [x] override cell on typing and cancel on Escape
- [x] show only not empty attribute suggestion sections
- [x] fill in generated link type name
- [x] do not refresh table on dialog open
- [x] fix removing uninitialized attribute
- [x] add margins around table
- [x] fix creating unwanted attribute on new link dialog
- [x] save view cursor on table destroy
- [ ] always show both scrollbars 
- [ ] fix suggested linked documents appearance

Some work still needs to be done here. Infinite scroll is out of scope of this pull-request.