### PR TITLE
Add permissions pipe #LMR-958

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -9,13 +9,13 @@
       "projectType": "application",
       "prefix": "",
       "schematics": {
-        "@schematics/angular:component": {
+        "@ngrx/schematics:component": {
           "spec": false
         },
-        "@schematics/angular:pipe": {
+        "@ngrx/schematics:pipe": {
           "spec": false
         },
-        "@schematics/angular:service": {
+        "@ngrx/schematics:service": {
           "spec": false
         }
       },

--- a/src/app/shared/pipes/permissions.pipe.ts
+++ b/src/app/shared/pipes/permissions.pipe.ts
@@ -1,0 +1,50 @@
+/*
+ * Lumeer: Modern Data Definition and Processing Platform
+ *
+ * Copyright (C) since 2017 Answer Institute, s.r.o. and/or its affiliates.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {Pipe, PipeTransform} from '@angular/core';
+import {Store} from '@ngrx/store';
+import {Observable} from 'rxjs/internal/Observable';
+import {map} from 'rxjs/operators';
+import {ResourceModel} from '../../core/model/resource.model';
+import {AppState} from '../../core/store/app.state';
+import {selectCurrentUserForWorkspace} from '../../core/store/users/users.state';
+import {userHasRoleInResource} from '../utils/resource.utils';
+
+@Pipe({
+  name: 'permissions',
+  pure: false
+})
+export class PermissionsPipe implements PipeTransform {
+
+  public constructor(private store: Store<AppState>) {
+  }
+
+  public transform(resource: ResourceModel, role: string): Observable<boolean> {
+    return this.store.select(selectCurrentUserForWorkspace).pipe(
+      map(currentUser => {
+        if (!currentUser || !resource) {
+          return false;
+        }
+
+        return userHasRoleInResource(currentUser, resource, role);
+      })
+    );
+  }
+
+}

--- a/src/app/shared/pipes/pipes.module.ts
+++ b/src/app/shared/pipes/pipes.module.ts
@@ -28,6 +28,7 @@ import {PerspectiveIconPipe} from './perspective-icon.pipe';
 import {PixelPipe} from './pixel.pipe';
 import {PrefixPipe} from './prefix.pipe';
 import { EmptyPipe } from './empty.pipe';
+import { PermissionsPipe } from './permissions.pipe';
 
 @NgModule({
   imports: [
@@ -43,6 +44,7 @@ import { EmptyPipe } from './empty.pipe';
     PerspectiveIconPipe,
     FilterPerspectivesPipe,
     EmptyPipe,
+    PermissionsPipe,
   ],
   exports: [
     LightenColorPipe,
@@ -54,6 +56,7 @@ import { EmptyPipe } from './empty.pipe';
     PerspectiveIconPipe,
     FilterPerspectivesPipe,
     EmptyPipe,
+    PermissionsPipe,
   ]
 })
 export class PipesModule {

--- a/src/app/shared/post-it-collections/post-it-collections.component.html
+++ b/src/app/shared/post-it-collections/post-it-collections.component.html
@@ -1,21 +1,21 @@
-<div *ngIf="collections && collections.length == 0 && !hasCreateRights()"
+<div *ngIf="collections && collections.length === 0 && !(project | permissions:'write' | async)"
      class="alert alert-warning mt-2"
      i18n="@@search.result.empty">
   We are sorry, but we have not found anything. Please do a more accurate search.
 </div>
 
-<div *ngIf="(collections && collections.length > 0) || hasCreateRights()">
+<div *ngIf="(collections && collections.length > 0) || (project | permissions:'write' | async)">
 
   <div class="d-flex mt-2 mb-1">
     <post-it-collection-add-button
       class="ml-1"
-      [disabled]="!hasCreateRights()"
+      [disabled]="!(project | permissions:'write' | async)"
       (clicked)="newCollection()">
     </post-it-collection-add-button>
 
     <post-it-collection-import-button
       class="ml-2"
-      [disabled]="!hasCreateRights()"
+      [disabled]="!(project | permissions:'write' | async)"
       [i18n]="i18n"
       (error)="notifyOfError($event)"
       (import)="onImportCollection($event)">
@@ -40,7 +40,6 @@
       (favoriteChange)="onFavoriteChange(collection.id, $event)"
       (togglePanel)="togglePanelVisible($event, idx)">
     </post-it-collection>
-
 
   </div>
 

--- a/src/app/shared/post-it-collections/post-it-collections.component.ts
+++ b/src/app/shared/post-it-collections/post-it-collections.component.ts
@@ -79,7 +79,7 @@ export class PostItCollectionsComponent implements OnInit, AfterViewInit, OnDest
 
   private workspace: Workspace;
 
-  private project: ProjectModel;
+  public project: ProjectModel;
 
   private currentUser: UserModel;
 
@@ -239,10 +239,6 @@ export class PostItCollectionsComponent implements OnInit, AfterViewInit, OnDest
 
   public createCollection(collection: CollectionModel) {
     this.store.dispatch(new CollectionsAction.Create({collection}));
-  }
-
-  public hasCreateRights(): boolean {
-    return this.project && this.currentUser && userHasRoleInResource(this.currentUser, this.project, Role.Write);
   }
 
   public getRoles(collection: CollectionModel): string[] {

--- a/src/app/shared/post-it-collections/post-it-collections.module.ts
+++ b/src/app/shared/post-it-collections/post-it-collections.module.ts
@@ -20,6 +20,7 @@
 import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {FormsModule} from '@angular/forms';
+import {PipesModule} from '../pipes/pipes.module';
 
 import {PostItCollectionsComponent} from './post-it-collections.component';
 import {PostItCollectionNameComponent} from './collection-name/post-it-collection-name.component';
@@ -37,7 +38,8 @@ import {RouterModule} from '@angular/router';
     FormsModule,
     PickerModule,
     ClickOutsideModule,
-    RouterModule
+    RouterModule,
+    PipesModule
   ],
   declarations: [
     LayoutItem,

--- a/src/app/shared/preview-results/preview-results.component.html
+++ b/src/app/shared/preview-results/preview-results.component.html
@@ -4,7 +4,7 @@
             class="btn btn-sm btn-success"
             title="Add Document"
             i18n-title="@@shared.preview.results.addDocument"
-            [disabled]="!hasWriteAccess"
+            [disabled]="!(selectCollection | permissions:'write' | async)"
             (click)="onNewDocument()">
       <i class="fa fa-plus-circle" aria-hidden="true"></i>
       <span class="font-weight-bold" i18n="@@shared.preview.results.addDocument">New Document</span>

--- a/src/app/shared/preview-results/preview-results.module.ts
+++ b/src/app/shared/preview-results/preview-results.module.ts
@@ -19,13 +19,15 @@
 
 import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
+import {PipesModule} from '../pipes/pipes.module';
 import {PreviewResultsComponent} from './preview-results.component';
 import {PreviewResultsTableComponent} from './preview-results-table/preview-results-table.component';
 import {PreviewResultsTabsComponent} from './preview-results-tabs/preview-results-tabs.component';
 
 @NgModule({
   imports: [
-    CommonModule
+    CommonModule,
+    PipesModule
   ],
   declarations: [
     PreviewResultsComponent,

--- a/src/app/shared/utils/resource.utils.ts
+++ b/src/app/shared/utils/resource.utils.ts
@@ -27,7 +27,7 @@ export function userHasManageRoleInResource(user: UserModel, resource: ResourceM
 }
 
 export function userHasRoleInResource(user: UserModel, resource: ResourceModel, role: string): boolean {
-  return userRolesInResource(user, resource).includes(role);
+  return userRolesInResource(user, resource).includes(role.toUpperCase());
 }
 
 export function userRolesInResource(user: UserModel, resource: ResourceModel): string[] {

--- a/src/app/view/perspectives/detail/detail-perspective.component.html
+++ b/src/app/view/perspectives/detail/detail-perspective.component.html
@@ -1,5 +1,11 @@
 <div class="container">
-  <preview-results (selectCollection)="selectCollection($event)" (selectDocument)="selectDocument($event)"></preview-results>
-  <document-detail *ngIf="selectedDocument" [collection]="selectedCollection" [document]="selectedDocument" [hasWriteAccess]="hasWriteAccess"></document-detail>
+  <preview-results (selectCollection)="selectCollection($event)"
+                   (selectDocument)="selectDocument($event)">
+  </preview-results>
+  <document-detail *ngIf="selectedDocument"
+                   [collection]="selectedCollection"
+                   [document]="selectedDocument"
+                   [hasWriteAccess]="selectedCollection | permissions:'write' | async">
+  </document-detail>
   <!--links-list></links-list-->
 </div>

--- a/src/app/view/perspectives/detail/detail-perspective.component.ts
+++ b/src/app/view/perspectives/detail/detail-perspective.component.ts
@@ -17,25 +17,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {Component, Input, OnDestroy, OnInit} from '@angular/core';
+import {Component, Input} from '@angular/core';
+import {CollectionModel} from '../../../core/store/collections/collection.model';
 import {DocumentModel} from '../../../core/store/documents/document.model';
 import {QueryModel} from '../../../core/store/navigation/query.model';
-import {CollectionModel} from '../../../core/store/collections/collection.model';
-import {selectCollectionById} from '../../../core/store/collections/collections.state';
-import {withLatestFrom} from 'rxjs/operators';
-import {selectCurrentUserForWorkspace} from '../../../core/store/users/users.state';
-import {Role} from '../../../core/model/role';
-import {userRolesInResource} from '../../../shared/utils/resource.utils';
-import {Subscription} from 'rxjs';
-import {Store} from '@ngrx/store';
-import {AppState} from '../../../core/store/app.state';
 
 @Component({
   selector: 'detail-perspective',
   templateUrl: './detail-perspective.component.html',
   styleUrls: ['./detail-perspective.component.scss']
 })
-export class DetailPerspectiveComponent implements OnDestroy {
+export class DetailPerspectiveComponent {
 
   public query: QueryModel;
 
@@ -46,47 +38,11 @@ export class DetailPerspectiveComponent implements OnDestroy {
 
   public selectedDocument: DocumentModel;
 
-  private userRightsSubscription: Subscription;
-
-  public hasWriteAccess = false;
-
-  private subscriptions = new Subscription();
-
-  constructor(private store: Store<AppState>) { }
-
-  public ngOnDestroy(): void {
-    this.unsubscribeAll();
-  }
-
-  private unsubscribeAll(): void {
-    this.subscriptions.unsubscribe();
-    this.unsubscribeUserRights();
-  }
-
   public selectCollection(collection: CollectionModel) {
     this.selectedCollection = collection;
-    this.hasWriteAccess = false;
-    this.subscribeUserRights();
   }
 
   public selectDocument(document: DocumentModel) {
     this.selectedDocument = document;
-  }
-
-  private subscribeUserRights(): void {
-    this.unsubscribeUserRights();
-
-    this.userRightsSubscription = this.store.select(selectCollectionById(this.selectedCollection.id)).pipe(
-      withLatestFrom(this.store.select(selectCurrentUserForWorkspace))
-    ).subscribe(([collection, user]) => {
-      const roles = userRolesInResource(user, collection);
-      this.hasWriteAccess = roles.includes(Role.Write);
-    });
-  }
-
-  private unsubscribeUserRights(): void {
-    if (this.userRightsSubscription) {
-      this.userRightsSubscription.unsubscribe();
-    }
   }
 }


### PR DESCRIPTION
I am introducing a brand new `PermissionsPipe` which will simplify checking access rights in the templates and reduce the amount of code you need to write.

I have already refactored some components using this pipe so you can see how to use it.

There are still some places where it can be used but they will require more complex refactoring and I didn't want to do that in this PR. Document post-its perspective is one example of such a place.