### PR TITLE
Optimize scripts bundle size #LMR-959

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -36,10 +36,10 @@
               "src/styles.css"
             ],
             "scripts": [
-              "node_modules/plotly.js/dist/plotly.min.js",
               "node_modules/hammerjs/hammer.min.js",
               "node_modules/muuri/muuri.min.js"
-            ]
+            ],
+            "vendorChunk": false
           },
           "configurations": {
             "production": {


### PR DESCRIPTION
The initial page of the application should now load only around 2.5 MB of JavaScript files.