### PR TITLE
Upload JavaScript source maps to Sentry

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -64,7 +64,7 @@
               "optimization": true,
               "outputHashing": "all",
               "showCircularDependencies": false,
-              "sourceMap": false,
+              "sourceMap": true,
               "vendorChunk": false
             },
             "staging": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -767,6 +767,26 @@
         "semver-intersect": "^1.1.2"
       }
     },
+    "@sentry/cli": {
+      "version": "1.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.34.0.tgz",
+      "integrity": "sha512-j2nYoci4yaA3dIL3Gheai2KKAtMdDGNipq7Ws9vO5SaG6uY0FQ0EXTxY0CAMPiNXdAXWstR5rdxPptyrhxPq7Q==",
+      "dev": true,
+      "requires": {
+        "https-proxy-agent": "^2.2.1",
+        "node-fetch": "^2.1.2",
+        "progress": "2.0.0",
+        "proxy-from-env": "^1.0.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
+          "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA==",
+          "dev": true
+        }
+      }
+    },
     "@types/auth0-js": {
       "version": "8.11.2",
       "resolved": "https://registry.npmjs.org/@types/auth0-js/-/auth0-js-8.11.2.tgz",
@@ -12172,6 +12192,12 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
+    },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -12369,8 +12395,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
       "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "proxy-middleware": {
       "version": "0.15.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@angular/language-service": "^6.0.3",
     "@compodoc/compodoc": "^1.1.3",
     "@ngrx/schematics": "^6.0.1",
+    "@sentry/cli": "^1.34.0",
     "@types/auth0-js": "^8.11.2",
     "@types/jasmine": "^2.8.8",
     "@types/jasminewd2": "~2.0.3",

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,20 @@
                      <goal>exec</goal>
                   </goals>
                </execution>
+              <execution>
+                <id>sentry-upload-sourcemaps</id>
+                <phase>generate-sources</phase>
+                <configuration>
+                  <executable>./sentry-upload-sourcemaps.sh</executable>
+                  <workingDirectory>${basedir}</workingDirectory>
+                  <environmentVariables>
+                    <PUBLIC_PATH>/${context.root}/</PUBLIC_PATH>
+                  </environmentVariables>
+                </configuration>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+              </execution>
             </executions>
          </plugin>
       </plugins>

--- a/sentry-upload-sourcemaps.sh
+++ b/sentry-upload-sourcemaps.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+export SENTRY_ORG=answer-institute-sro
+export SENTRY_PROJECT=lumeerio
+
+if [ "$LUMEER_ENV" != "production" ]
+then
+  exit 0
+fi
+
+if [ -z "$BUILD_NUMBER" ]
+then
+  echo -e "BUILD_NUMBER is not defined."
+  exit 1
+fi
+
+if [ -z "$PUBLIC_PATH" ]
+then
+  echo -e "PUBLIC_PATH is not defined."
+  exit 1
+fi
+
+if [ -z "$SENTRY_AUTH_TOKEN" ]
+then
+  echo -e "SENTRY_AUTH_TOKEN is not defined."
+  exit 1
+fi
+
+./node_modules/.bin/sentry-cli releases new $BUILD_NUMBER \
+  && ./node_modules/.bin/sentry-cli releases files $BUILD_NUMBER upload-sourcemaps --url-prefix https://get.lumeer.io$PUBLIC_PATH ./dist/lumeer


### PR DESCRIPTION
Every Maven build with `LUMEER_ENV` set to 'production` will upload generated JavaScript source maps to Sentry. This will allow us to easily see which line of our source code caused an error reported to Sentry.