### PR TITLE
Fix view controls on mobile devices #LMR-1047

### DIFF
--- a/src/app/shared/top-panel/top-panel.component.html
+++ b/src/app/shared/top-panel/top-panel.component.html
@@ -1,75 +1,71 @@
-<div class="grid">
-  <div #workspacePanel class="d-flex justify-content-left workspace-panel">
-    <div class="panel-item mr-1">
-      <lumeer-logo [height]="48"
-                   [link]="['/']"
-                   [text]="!(workspace | workspaceSet) ? 'Lumeer' : null">
-      </lumeer-logo>
-    </div>
-    <div class="d-flex"
-         *ngIf="workspace | workspaceSet">
-      <ul class="navbar navbar-triangle my-0 p-0 mr-3 flex-nowrap">
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown1" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <i [class]="organization?.icon" [style.color]="organization?.color"></i>&nbsp;{{organization?.code}}
-          </a>
-          <resource-menu
-            labelledBy="navbarDropdown1"
-            [type]="organizationResourceType"
-            [resource]="organization"
-            [workspace]="workspace"
-            (onResourceSelect)="selectOrganization($event)"
-            (onNewResource)="createNewOrganization()"
-          >
-          </resource-menu>
-        </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown2" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <i [class]="project?.icon" [style.color]="project?.color"></i>&nbsp;{{project?.code}}
-          </a>
-          <resource-menu
-            labelledBy="navbarDropdown2"
-            [type]="projectResourceType"
-            [resource]="project"
-            [workspace]="workspace"
-            (onResourceSelect)="selectProject($event)"
-            (onNewResource)="createNewProject(organization)"
-          >
-          </resource-menu>
-        </li>
-      </ul>
-    </div>
+<div #logo
+     class="logo panel-item">
+  <lumeer-logo [height]="48"
+               [link]="['/']"
+               [text]="!(workspace | workspaceSet) ? 'Lumeer' : null">
+  </lumeer-logo>
+</div>
+<div #workspacePanel
+     class="workspace-panel d-flex"
+     *ngIf="workspace | workspaceSet">
+  <ul class="navbar navbar-triangle my-0 p-0 mr-3 flex-nowrap">
+    <li class="nav-item dropdown">
+      <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown1" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <i [class]="organization?.icon" [style.color]="organization?.color"></i>&nbsp;{{organization?.code}}
+      </a>
+      <resource-menu
+        labelledBy="navbarDropdown1"
+        [type]="organizationResourceType"
+        [resource]="organization"
+        [workspace]="workspace"
+        (onResourceSelect)="selectOrganization($event)"
+        (onNewResource)="createNewOrganization()">
+      </resource-menu>
+    </li>
+    <li class="nav-item dropdown">
+      <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown2" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <i [class]="project?.icon" [style.color]="project?.color"></i>&nbsp;{{project?.code}}
+      </a>
+      <resource-menu
+        labelledBy="navbarDropdown2"
+        [type]="projectResourceType"
+        [resource]="project"
+        [workspace]="workspace"
+        (onResourceSelect)="selectProject($event)"
+        (onNewResource)="createNewProject(organization)">
+      </resource-menu>
+    </li>
+  </ul>
+</div>
+
+<div class="d-flex justify-content-end user-panel">
+
+  <div *ngIf="freePlan$ | async"
+       class="panel-item">
+    <a (click)="goToOrganizationDetail()">
+      <span class="bagde badge-danger badge-pill mr-2 py-1" i18n="@@panel.plan.free">Free&nbsp;Plan</span>
+    </a>
   </div>
 
-  <div class="d-flex justify-content-end user-panel">
-
-    <div *ngIf="freePlan$ | async"
-         class="panel-item">
-      <a (click)="goToOrganizationDetail()">
-        <span class="bagde badge-danger badge-pill mr-2 py-1" i18n="@@panel.plan.free">Free&nbsp;Plan</span>
-      </a>
-    </div>
-
-    <!-- TODO remove once Angular supports ICU messages in attributes -->
-    <div hidden>
+  <!-- TODO remove once Angular supports ICU messages in attributes -->
+  <div hidden>
         <span #notificationsTitle
               i18n="@@panel.notifications">
           {notifications, plural, =0 {No new notifications} =1 {One new notification} =2 {2 new notifications} =3 {3 new notifications} =4 {4 new notifications} other { {{notifications}} new notifications}}
         </span>
-    </div>
-
-    <div class="panel-item mx-2"
-         [title]="removeHtmlComments(notificationsTitle)">
-      <i *ngIf="notifications === 0"
-         class="fa fa-bell fa-lg text-secondary"></i>
-      <i *ngIf="notifications > 0"
-         class="fa fa-bell fa-lg text-warning"></i>
-    </div>
-
-    <user-menu></user-menu>
   </div>
 
-  <search-box *ngIf="(workspace | workspaceSet) && searchBoxShown"
-              class="search-box">
-  </search-box>
+  <div class="panel-item mx-2"
+       [title]="removeHtmlComments(notificationsTitle)">
+    <i *ngIf="notifications === 0"
+       class="fa fa-bell fa-lg text-secondary"></i>
+    <i *ngIf="notifications > 0"
+       class="fa fa-bell fa-lg text-warning"></i>
+  </div>
+
+  <user-menu></user-menu>
 </div>
+
+<search-box *ngIf="(workspace | workspaceSet) && searchBoxShown"
+            class="search-box">
+</search-box>

--- a/src/app/shared/top-panel/top-panel.component.scss
+++ b/src/app/shared/top-panel/top-panel.component.scss
@@ -9,38 +9,46 @@ $top-panel-height: 48px;
   white-space: nowrap;
 }
 
-.grid {
+:host {
   display: grid;
   grid-gap: 10px;
+  grid-template-areas: "logo user-panel" "workspace-panel workspace-panel" "search-box search-box";
   grid-template-columns: 1fr 1fr;
   align-items: center;
 }
 
+.logo {
+  grid-area: logo;
+  justify-self: start;
+}
+
+.workspace-panel {
+  grid-area: workspace-panel;
+}
+
 .search-box {
-  grid-row: 2;
-  grid-column: 1 / span 2;
+  grid-area: search-box;
+}
+
+.user-panel {
+  grid-area: user-panel;
+}
+
+@media (min-width: 576px) and (max-width: 1199.98px) {
+  :host {
+    grid-template-areas: "logo workspace-panel user-panel" "search-box search-box search-box";
+    grid-template-columns: auto auto 1fr;
+  }
 }
 
 @media (min-width: 1200px) {
 
-  .grid {
-    grid-template-columns: auto 1fr auto;
-  }
-
-  .workspace-panel {
-    grid-row: 1;
-    grid-column: 1;
-  }
-
-  .search-box {
-    display: block;
-    grid-row: 1;
-    grid-column: 2;
+  :host {
+    grid-template-areas: "logo workspace-panel search-box user-panel";
+    grid-template-columns: auto auto 1fr auto;
   }
 
   .user-panel {
-    grid-row: 1;
-    grid-column: 3;
     width: var(--top-panel-side-width);
   }
 

--- a/src/app/shared/top-panel/top-panel.component.ts
+++ b/src/app/shared/top-panel/top-panel.component.ts
@@ -59,6 +59,9 @@ export class TopPanelComponent implements OnInit, AfterViewChecked {
   @Input()
   public searchBoxShown: boolean;
 
+  @ViewChild('logo')
+  public logo: ElementRef;
+
   @ViewChild('workspacePanel')
   public workspacePanel: ElementRef;
 
@@ -125,7 +128,9 @@ export class TopPanelComponent implements OnInit, AfterViewChecked {
   }
 
   public ngAfterViewChecked() {
-    const width = this.workspacePanel.nativeElement.clientWidth;
+    const logoWidth = this.logo.nativeElement.clientWidth;
+    const workspacePanelWidth = this.workspacePanel.nativeElement.clientWidth;
+    const width = logoWidth + 10 + workspacePanelWidth;
     document.body.style.setProperty('--top-panel-side-width', `${width}px`);
   }
 

--- a/src/app/view/view-controls/view-controls.component.html
+++ b/src/app/view/view-controls/view-controls.component.html
@@ -1,47 +1,49 @@
 <ng-container *ngIf="view | viewControlsInfo:name:(config$ | async):(perspective$ | async):(query$ | async) | async as viewControlsInfo">
-  <form class="form-inline d-flex flex-nowrap mt-2">
-    <div class="input-group flex-nowrap mb-2">
-      <div class="input-group-prepend">
-      <span class="input-group-text">
-        <strong *ngIf="novice"
-                i18n="@@view.perspective.guide.select">1.&nbsp;Select View</strong>
-        <i *ngIf="!novice"
-           class="far fa-eye fa-fw">
-        </i>
-      </span>
-      </div>
-      <div *ngVar="perspective$ | async as perspective"
-           (click)="onPerspectiveChooserClick($event)"
-           title="Perspective" i18n-title="@@view.perspective">
-        <button aria-expanded="false"
-                aria-haspopup="true"
-                class="btn btn-outline-gray-600 sharp-top-left sharp-bottom-left dropdown-toggle"
-                data-toggle="dropdown"
-                id="perspectiveDropdown"
-                type="button">
-          <i class="fa-fw {{perspective | perspectiveIcon}}"></i>
-          <span class="ml-sm-1 text-nowrap"
-                i18n="@@view.perspective.name">{perspective, select, detail {Detail} postit {Post-it} chart {Chart} search {Search} table {Table} smartdoc {Smart document}}</span>
-        </button>
-        <div aria-labelledby="perspectiveDropdown"
-             class="dropdown-menu">
-          <a *ngFor="let aperspective of perspectives | filterPerspectives:view.query"
-             [class.active]="perspective === aperspective"
-             (click)="onSelectPerspective(aperspective)"
-             class="dropdown-item">
-            <i class="fa-fw {{aperspective | perspectiveIcon}}"></i>
-            <span class="ml-1 text-nowrap"
-                  i18n="@@view.perspective.name">{aperspective, select, detail {Detail} postit {Post-it} chart {Chart} search {Search} table {Table} smartdoc {Smart document}}</span>
-          </a>
+  <form class="view-controls-grid mt-2">
+    <div class="perspective d-flex align-items-center justify-content-start">
+      <div class="input-group flex-nowrap mr-2 mb-2">
+        <div class="input-group-prepend">
+        <span class="input-group-text">
+          <strong *ngIf="novice"
+                  i18n="@@view.perspective.guide.select">1.&nbsp;Select View</strong>
+          <i *ngIf="!novice"
+             class="far fa-eye fa-fw">
+          </i>
+        </span>
+        </div>
+        <div *ngVar="perspective$ | async as perspective"
+             (click)="onPerspectiveChooserClick($event)"
+             title="Perspective" i18n-title="@@view.perspective">
+          <button aria-expanded="false"
+                  aria-haspopup="true"
+                  class="btn btn-outline-gray-600 sharp-top-left sharp-bottom-left dropdown-toggle"
+                  data-toggle="dropdown"
+                  id="perspectiveDropdown"
+                  type="button">
+            <i class="fa-fw {{perspective | perspectiveIcon}}"></i>
+            <span class="ml-sm-1 text-nowrap"
+                  i18n="@@view.perspective.name">{perspective, select, detail {Detail} postit {Post-it} chart {Chart} search {Search} table {Table} smartdoc {Smart document}}</span>
+          </button>
+          <div aria-labelledby="perspectiveDropdown"
+               class="dropdown-menu">
+            <a *ngFor="let aperspective of perspectives | filterPerspectives:view.query"
+               [class.active]="perspective === aperspective"
+               (click)="onSelectPerspective(aperspective)"
+               class="dropdown-item">
+              <i class="fa-fw {{aperspective | perspectiveIcon}}"></i>
+              <span class="ml-1 text-nowrap"
+                    i18n="@@view.perspective.name">{aperspective, select, detail {Detail} postit {Post-it} chart {Chart} search {Search} table {Table} smartdoc {Smart document}}</span>
+            </a>
+          </div>
         </div>
       </div>
+
+      <i *ngIf="novice"
+         class="view-arrow fas fa-arrow-circle-right mr-2 mb-2 text-muted">
+      </i>
     </div>
 
-    <i *ngIf="novice"
-       class="fas fa-arrow-circle-right ml-2 mb-2 text-muted">
-    </i>
-
-    <div class="input-group flex-nowrap flex-fill ml-2 mb-2">
+    <div class="view-name input-group flex-nowrap flex-fill mb-2">
       <div class="input-group-prepend">
       <span class="input-group-text">
         <strong *ngIf="novice"

--- a/src/app/view/view-controls/view-controls.component.scss
+++ b/src/app/view/view-controls/view-controls.component.scss
@@ -1,5 +1,29 @@
 @import "../../../styles/variables";
 
+.view-controls-grid {
+  display: grid;
+  grid-template-areas: "perspective" "view-name";
+
+  @media (min-width: 576px) {
+    grid-template-areas: "perspective view-name";
+    grid-template-columns: auto 1fr;
+  }
+}
+
+.perspective {
+  grid-area: perspective;
+}
+
+@media (max-width: 575.98px) {
+  .view-arrow {
+    display: none;
+  }
+}
+
+.view-name {
+  grid-area: view-name;
+}
+
 .dropdown {
   cursor: default;
 }


### PR DESCRIPTION
The application should now fit into the screen of the smallest devices (e.g. iPhone SE).

![localhost_7000_ui_w_lmr_devel_view_table_query 7b 22collectionids 22_ 5b 225af6b48744c8b8266bb4d7e8 22 5d 7d iphone 5_se](https://user-images.githubusercontent.com/2910853/43401173-bb4084e2-940f-11e8-8001-b45509d044c2.png)

However, it is not an ideal solution since a lot of vertical space is covered just by control panels. In the future, we will need to put all these controls into a dropdown menu which will only be shown on mobile devices.