### PR TITLE
Do not move cursor on new document added to table #LMR-1056

### DIFF
--- a/src/app/view/perspectives/table/body/rows/table-rows.component.ts
+++ b/src/app/view/perspectives/table/body/rows/table-rows.component.ts
@@ -98,7 +98,6 @@ export class TableRowsComponent implements OnChanges, OnDestroy {
           .concat({...EMPTY_TABLE_ROW, rowId: Math.random().toString(36).substr(2, 9)});
         if (rows.length > 1) {
           this.store$.dispatch(new TablesAction.ReplaceRows({cursor, rows, deleteCount: 1}));
-          this.store$.dispatch(new TablesAction.MoveCursor({direction: Direction.Down}));
         }
       })
     );


### PR DESCRIPTION
This should also fix problem we see in Sentry as `Cannot read property 'children' of undefined`.

However, it does not move cursor to the next line when you create a new document in a table.