### PR TITLE
Do not build UI twice in Travis #LMR-1164

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ before_install:
   - "nvm install v8.11.4"
   - "nvm use v8.11.4"
   - "npm i -g npm@latest"
+install:
+  - "npm install"
 node_js:
   - "lts/*"
 script:

--- a/travis.sh
+++ b/travis.sh
@@ -34,19 +34,15 @@ echo "Linting..."
 npm run lint >> $BUILD_OUTPUT 2>&1
 dump_output
 
-echo "Building UI..."
-npm run build >> $BUILD_OUTPUT 2>&1
-dump_output
+echo "Starting UI..."
+npm run start:en >> $BUILD_OUTPUT 2>&1 &
+while ! curl --output /dev/null --silent -r 0-0 --fail "http://localhost:7000/ui"; do
+  sleep 3
+done
 
 echo "Starting backend..."
 ./travis-start-engine.sh >> $BUILD_OUTPUT 2>&1
 dump_output
-
-echo "Starting UI..."
-npm start >> $BUILD_OUTPUT 2>&1 &
-while ! curl --output /dev/null --silent -r 0-0 --fail "http://localhost:7000/ui"; do
-  sleep 3
-done
 
 echo "Testing UI..."
 npm run cypress:run --  --record --key b43d988f-5145-4a2b-9df3-ce3b1607f203 >> $BUILD_OUTPUT 2>&1


### PR DESCRIPTION
Do not run `ng build` and instead start the application with AOT compiler in order to speed up the whole Travis build process and catch all AOT compilation errors as before.