### PR TITLE
Fix forgotten env properties

### DIFF
--- a/env-vars.js
+++ b/env-vars.js
@@ -14,6 +14,8 @@ config.SENTRY_DSN = env.SENTRY_DSN;
 config.AUTH_CLIENT_ID = env.AUTH_CLIENT_ID;
 config.AUTH_DOMAIN = env.AUTH_DOMAIN;
 config.SESSION_TIMEOUT = env.SESSION_TIMEOUT;
+config.PUSHER_CLUSTER = env.PUSHER_CLUSTER;
+config.PUSHER_KEY = env.PUSHER_KEY;
 
 writeFileSync('./src/environments/.env.json', JSON.stringify(config));
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "start:en": "npm run reset-env && ng serve --configuration=en",
     "test": "ng test",
     "test:watch": "ng test --watch",
-    "workaround": "sed -i -e 's|/\\*\\*|/*|' node_modules/plotly.js/src/lib/polygon.js",
     "cypress:open": "npx cypress open",
     "cypress:run": "npx cypress run"
   },


### PR DESCRIPTION
I forgot to consume env vars and store them in a file during build.