### PR TITLE
Fix uninitialized link instance permissions #LMR-1666

### DIFF
--- a/src/app/shared/pipes/permissions/link-instance-permissions.pipe.ts
+++ b/src/app/shared/pipes/permissions/link-instance-permissions.pipe.ts
@@ -18,15 +18,14 @@
  */
 
 import {Injectable, Pipe, PipeTransform} from '@angular/core';
-import {Store} from '@ngrx/store';
-import {Observable, of, combineLatest as observableCombineLatest} from 'rxjs';
-import {map, mergeMap} from 'rxjs/operators';
-import {AppState} from '../../../core/store/app.state';
-import {DocumentPermissionsPipe} from './document-permissions.pipe';
-import {LinkInstance} from '../../../core/store/link-instances/link.instance';
-import {DocumentModel} from '../../../core/store/documents/document.model';
-import {selectDocumentsByIds} from '../../../core/store/documents/documents.state';
+import {select, Store} from '@ngrx/store';
+import {Observable, of} from 'rxjs';
+import {mergeMap} from 'rxjs/operators';
 import {AllowedPermissions} from '../../../core/model/allowed-permissions';
+import {AppState} from '../../../core/store/app.state';
+import {LinkInstance} from '../../../core/store/link-instances/link.instance';
+import {selectLinkTypeById} from '../../../core/store/link-types/link-types.state';
+import {LinkTypePermissionsPipe} from './link-type-permissions.pipe';
 
 @Pipe({
   name: 'linkInstancePermissions',
@@ -36,41 +35,16 @@ import {AllowedPermissions} from '../../../core/model/allowed-permissions';
   providedIn: 'root',
 })
 export class LinkInstancePermissionsPipe implements PipeTransform {
-  public constructor(private store: Store<AppState>, private documentPermissionsPipe: DocumentPermissionsPipe) {}
+  public constructor(private store: Store<AppState>, private linkTypePermissionsPipe: LinkTypePermissionsPipe) {}
 
   public transform(linkInstance: LinkInstance): Observable<AllowedPermissions> {
     if (!linkInstance) {
       return of({});
     }
 
-    return this.getDocumentsForLinkInstance(linkInstance).pipe(
-      mergeMap(documents => {
-        if (documents.length !== 2) {
-          return of({});
-        }
-
-        return observableCombineLatest(
-          this.documentPermissionsPipe.transform(documents[0]),
-          this.documentPermissionsPipe.transform(documents[1])
-        ).pipe(
-          map(([ap1, ap2]) => {
-            return {
-              read: ap1.read && ap2.read,
-              write: ap1.write && ap2.write,
-              manage: ap1.manage && ap2.manage,
-              readWithView: ap1.readWithView && ap2.readWithView,
-              writeWithView: ap1.writeWithView && ap2.writeWithView,
-              manageWithView: ap1.manageWithView && ap2.manageWithView,
-            };
-          })
-        );
-      })
+    return this.store.pipe(
+      select(selectLinkTypeById(linkInstance.linkTypeId)),
+      mergeMap(linkType => this.linkTypePermissionsPipe.transform(linkType))
     );
-  }
-
-  private getDocumentsForLinkInstance(linkInstance: LinkInstance): Observable<DocumentModel[]> {
-    return this.store
-      .select(selectDocumentsByIds(linkInstance.documentIds))
-      .pipe(map(documents => documents.filter(document => !!document)));
   }
 }

--- a/src/app/view/perspectives/table/body/rows/cell-group/data-cell/table-data-cell.component.ts
+++ b/src/app/view/perspectives/table/body/rows/cell-group/data-cell/table-data-cell.component.ts
@@ -370,7 +370,7 @@ export class TableDataCellComponent implements OnInit, OnChanges, OnDestroy {
       event.preventDefault();
       this.attribute$.pipe(first()).subscribe(attribute => {
         if (this.allowedPermissions && this.allowedPermissions.writeWithView && this.isAttributeEditable(attribute)) {
-          this.editing$.next(true); // TODO maybe set edited attribute?
+          this.editing$.next(true);
         }
       });
     }


### PR DESCRIPTION
I have switched checking link instance permissions from using its documents permissions to using its link type permissions. It should behave the same way since at the end only collection permissions are checked. 

The way it was implemented before prevented editing of link attribute column in uninitialized linked table row. Because table creates link instance objects for uninitialized linked rows. However, these objects do not have document IDs since the linked documents do not exist yet. But they always have link type as it must already exist.