### PR TITLE
Fix sharing view in search perspective #LMR-1690

### DIFF
--- a/src/app/core/store/views/views.effects.ts
+++ b/src/app/core/store/views/views.effects.ts
@@ -219,15 +219,15 @@ export class ViewsEffects {
   public setPermission$ = this.actions$.pipe(
     ofType<ViewsAction.SetPermissions>(ViewsActionType.SET_PERMISSIONS),
     concatMap(action => {
-      const permissionsDto: PermissionDto[] = action.payload.permissions.map(model =>
-        PermissionsConverter.toPermissionDto(model)
-      );
+      const {permissions, type, viewId} = action.payload;
+
+      const permissionsDto: PermissionDto[] = permissions.map(model => PermissionsConverter.toPermissionDto(model));
 
       let observable;
-      if (action.payload.type === PermissionType.Users) {
-        observable = this.viewService.updateUserPermission(permissionsDto);
+      if (type === PermissionType.Users) {
+        observable = this.viewService.updateUserPermission(viewId, permissionsDto);
       } else {
-        observable = this.viewService.updateGroupPermission(permissionsDto);
+        observable = this.viewService.updateGroupPermission(viewId, permissionsDto);
       }
       return observable.pipe(
         concatMap(() => of(new ViewsAction.SetPermissionsSuccess(action.payload))),


### PR DESCRIPTION
We should make all services stateless in the future. Even `organizationId` and `projectId` should always be passed as arguments of their methods. Otherwise, we will encounter problems like this as the application keeps growing and becomes more complicated.