### PR TITLE
Keep file attachments up to date #LMR-1969

### DIFF
--- a/src/app/core/rest/document.service.ts
+++ b/src/app/core/rest/document.service.ts
@@ -99,8 +99,13 @@ export class DocumentService extends BaseService {
     return this.httpClient.get<DocumentDto>(`${this.apiPrefix({collectionId})}/${documentId}`);
   }
 
-  public duplicateDocuments(collectionId: string, documentIds: string[]): Observable<DocumentDto[]> {
-    return this.httpClient.post<DocumentDto[]>(`${this.apiPrefix({collectionId})}/duplicate`, documentIds);
+  public duplicateDocuments(
+    collectionId: string,
+    documentIds: string[],
+    correlationId?: string
+  ): Observable<DocumentDto[]> {
+    const options = correlationId ? {headers: {correlation_id: correlationId}} : {};
+    return this.httpClient.post<DocumentDto[]>(`${this.apiPrefix({collectionId})}/duplicate`, documentIds, options);
   }
 
   private apiPrefix(workspace?: Workspace): string {

--- a/src/app/core/store/collections/collection.util.ts
+++ b/src/app/core/store/collections/collection.util.ts
@@ -17,12 +17,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {Attribute, Collection} from './collection';
+import {AllowedPermissions} from '../../model/allowed-permissions';
+import {Constraint, ConstraintType} from '../../model/data/constraint';
 import {LinkType} from '../link-types/link.type';
-import {Constraint} from '../../model/data/constraint';
 import {AttributeFilter, ConditionType, Query} from '../navigation/query';
 import {conditionFromString, getQueryFiltersForCollection, getQueryFiltersForLinkType} from '../navigation/query.util';
-import {AllowedPermissions} from '../../model/allowed-permissions';
+import {Attribute, Collection} from './collection';
 
 export function isCollectionAttributeEditable(
   attributeId: string,
@@ -150,4 +150,8 @@ export function findAttribute(attributes: Attribute[], attributeId: string): Att
 export function findAttributeConstraint(attributes: Attribute[], attributeId: string): Constraint {
   const attribute = findAttribute(attributes, attributeId);
   return attribute && attribute.constraint;
+}
+
+export function hasAttributeType(entity: Collection | LinkType, constraintType: ConstraintType): boolean {
+  return entity && entity.attributes.some(attr => attr.constraint && attr.constraint.type === constraintType);
 }

--- a/src/app/core/store/documents/documents.action.ts
+++ b/src/app/core/store/documents/documents.action.ts
@@ -127,7 +127,7 @@ export namespace DocumentsAction {
   export class UpdateSuccess implements Action {
     public readonly type = DocumentsActionType.UPDATE_SUCCESS;
 
-    public constructor(public payload: {document: DocumentModel}) {}
+    public constructor(public payload: {document: DocumentModel; originalDocument: DocumentModel}) {}
   }
 
   export class UpdateFailure implements Action {
@@ -142,6 +142,7 @@ export namespace DocumentsAction {
     public constructor(
       public payload: {
         collectionId: string;
+        correlationId?: string;
         documentIds: string[];
         onSuccess?: (documents: DocumentModel[]) => void;
         onFailure?: (error: any) => void;

--- a/src/app/core/store/link-instances/link-instances.action.ts
+++ b/src/app/core/store/link-instances/link-instances.action.ts
@@ -107,7 +107,7 @@ export namespace LinkInstancesAction {
   export class UpdateSuccess implements Action {
     public readonly type = LinkInstancesActionType.UPDATE_SUCCESS;
 
-    public constructor(public payload: {linkInstance: LinkInstance}) {}
+    public constructor(public payload: {linkInstance: LinkInstance; originalLinkInstance: LinkInstance}) {}
   }
 
   export class UpdateFailure implements Action {

--- a/src/app/core/store/store.utils.ts
+++ b/src/app/core/store/store.utils.ts
@@ -26,7 +26,7 @@ export function createCallbackActions<T>(callback: (result: T) => void, result?:
 }
 
 export function emitErrorActions(error: any, onFailure?: (error: any) => void): Observable<Action> {
-  const actions: Action[] = [];
+  const actions: Action[] = [new CommonAction.HandleError({error})];
   if (onFailure) {
     actions.push(new CommonAction.ExecuteCallback({callback: () => onFailure(error)}));
   }

--- a/src/app/core/store/tables/tables.effects.ts
+++ b/src/app/core/store/tables/tables.effects.ts
@@ -846,13 +846,11 @@ export class TablesEffects {
 
           return [
             new TablesAction.AddPrimaryRows({cursor: {...cursor, rowPath: [cursor.rowPath[0] + 1]}, rows: [emptyRow]}),
-            new DocumentsAction.Create({
-              document: {
-                correlationId: emptyRow.correlationId,
-                collectionId: document.collectionId,
-                data: {...document.data},
-              },
-              callback: documentId => duplicateLinkedDocuments(documentId),
+            new DocumentsAction.Duplicate({
+              correlationId: emptyRow.correlationId,
+              collectionId: document.collectionId,
+              documentIds: [document.id],
+              onSuccess: documents => duplicateLinkedDocuments(documents[0].id),
             }),
           ];
         })

--- a/src/app/shared/data-input/files/files-data-input.component.ts
+++ b/src/app/shared/data-input/files/files-data-input.component.ts
@@ -155,7 +155,6 @@ export class FilesDataInputComponent implements OnInit, OnChanges {
 
   private onSuccess(fileAttachment: FileAttachment) {
     this.showSuccessNotification();
-    this.refreshFileAttachment(fileAttachment);
     this.addFileNameToData(fileAttachment.fileName);
   }
 
@@ -164,19 +163,6 @@ export class FilesDataInputComponent implements OnInit, OnChanges {
       this.i18n({
         id: 'file.attachment.upload.success',
         value: 'The file is successfully saved.',
-      })
-    );
-  }
-
-  private refreshFileAttachment(fileAttachment: FileAttachment) {
-    const {collectionId, documentId, linkTypeId, linkInstanceId, attributeId} = fileAttachment;
-    this.store$.dispatch(
-      new FileAttachmentsAction.Get({
-        collectionId,
-        documentId,
-        linkTypeId,
-        linkInstanceId,
-        attributeId,
       })
     );
   }

--- a/src/app/shared/utils/data/has-files-attribute-changed.ts
+++ b/src/app/shared/utils/data/has-files-attribute-changed.ts
@@ -1,0 +1,44 @@
+/*
+ * Lumeer: Modern Data Definition and Processing Platform
+ *
+ * Copyright (C) since 2017 Lumeer.io, s.r.o. and/or its affiliates.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {ConstraintType} from '../../../core/model/data/constraint';
+import {Collection} from '../../../core/store/collections/collection';
+import {DocumentModel} from '../../../core/store/documents/document.model';
+import {LinkInstance} from '../../../core/store/link-instances/link.instance';
+import {LinkType} from '../../../core/store/link-types/link.type';
+
+export function hasFilesAttributeChanged(
+  parent: Collection | LinkType,
+  entity: DocumentModel | LinkInstance,
+  previousEntity: DocumentModel | LinkInstance
+): boolean {
+  const filesAttributeIds = ((parent && parent.attributes) || [])
+    .filter(attr => attr.constraint && attr.constraint.type === ConstraintType.Files)
+    .map(attr => attr.id);
+
+  if (filesAttributeIds.length === 0) {
+    return false;
+  }
+
+  return filesAttributeIds.some(
+    attrId =>
+      ((entity && entity.data && entity.data[attrId]) || '') !==
+      ((previousEntity && previousEntity.data && previousEntity.data[attrId]) || '')
+  );
+}


### PR DESCRIPTION
* use duplicate endpoint to clone primary document
* reload file attachments on document changes
* reload file attachments on link instance changes
* prevent multiple file attachment reloads