### PR TITLE
Fix old version of Git in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:12-browsers
+      - image: circleci/node:12-buster-browsers
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images


### PR DESCRIPTION
* use Debian 10 "Buster" which comes with git version 2.20